### PR TITLE
Fix malware cross-links

### DIFF
--- a/_layouts/threat_actor.html
+++ b/_layouts/threat_actor.html
@@ -146,6 +146,53 @@ layout: default
       {{ content }}
     </div>
 
+    <script>
+      (function () {
+        var content = document.currentScript.previousElementSibling;
+        if (!content) return;
+
+        var malwareHeading = Array.prototype.find.call(content.querySelectorAll('h2'), function (heading) {
+          return heading.textContent.trim() === 'Malware and Tools';
+        });
+        if (!malwareHeading) return;
+
+        fetch('{{ "/api/malware_index.json" | relative_url }}')
+          .then(function (response) { return response.json(); })
+          .then(function (data) {
+            var malwareLinks = {};
+            (data.malware || []).forEach(function (malware) {
+              malwareLinks[malware.name.toLowerCase()] = malware.url;
+              malwareLinks[malware.slug] = malware.url;
+            });
+
+            var node = malwareHeading.nextElementSibling;
+            while (node && node.tagName !== 'H2') {
+              if (node.tagName === 'UL' || node.tagName === 'OL') {
+                Array.prototype.forEach.call(node.querySelectorAll('li'), function (item) {
+                  if (item.querySelector('a')) return;
+
+                  var label = item.querySelector('strong') || item;
+                  var name = label.textContent.trim();
+                  var url = malwareLinks[name.toLowerCase()] || malwareLinks[slugify(name)];
+                  if (!url) return;
+
+                  var link = document.createElement('a');
+                  link.href = url;
+                  link.textContent = label.textContent;
+                  label.textContent = '';
+                  label.appendChild(link);
+                });
+              }
+              node = node.nextElementSibling;
+            }
+          });
+
+        function slugify(value) {
+          return String(value).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        }
+      }());
+    </script>
+
     {% if profile_analyst_notes %}
     <aside class="analyst-notes-panel">
       <h2>Analyst Notes</h2>

--- a/scripts/validate-content.rb
+++ b/scripts/validate-content.rb
@@ -112,6 +112,7 @@ class ContentValidator
     validate_api_wrapper_bindings
     validate_ioc_shards
     validate_malware_actor_links
+    validate_threat_actor_malware_links
     validate_duplicate_ioc_sections
 
     print_results
@@ -605,6 +606,27 @@ class ContentValidator
     end
   end
 
+  def validate_threat_actor_malware_links
+    puts 'Validating threat actor malware links...'
+
+    malware_urls = JSON.parse(File.read('_data/generated/malware_index.json')).fetch('malware', []).map { |entry| entry['url'] }.to_set
+    Dir.glob('_threat_actors/*.md').sort.each do |file|
+      page = parse_page(file)
+      section = extract_section(page[:body], 'Malware and Tools')
+      next if section.empty?
+
+      extract_malware_names(section).each do |name|
+        slug = slugify(name)
+        next if slug.empty?
+
+        url = "/malware/#{slug}/"
+        add_error(file, "Malware entry '#{name}' does not resolve to #{url}") unless malware_urls.include?(url)
+      end
+    end
+  rescue StandardError => e
+    add_error('_data/generated/malware_index.json', "Unable to validate threat actor malware links: #{e.message}")
+  end
+
   def validate_duplicate_ioc_sections
     puts 'Checking for duplicated IOC indicators across pages...'
 
@@ -631,6 +653,24 @@ class ContentValidator
 
   def safe_load_yaml(content)
     YAML.safe_load(content, permitted_classes: [], aliases: false)
+  end
+
+  def extract_malware_names(section)
+    section.each_line.filter_map do |line|
+      stripped = line.strip
+      next unless stripped.match?(/^[-*]\s+/)
+
+      content = stripped.sub(/^[-*]\s+/, '').strip
+      if (match = content.match(/^\*\*(.+?)\*\*/))
+        match[1].strip
+      else
+        content.gsub(/\[([^\]]+)\]\([^\)]+\)/, '\1').gsub(/[*_`]/, '').strip
+      end
+    end.reject { |name| name.empty? || name.match?(/information pending/i) }
+  end
+
+  def slugify(value)
+    value.to_s.downcase.gsub(/[^a-z0-9]+/, '-').gsub(/^-|-$/, '')
   end
 
   def add_error(file, message)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes malware section generation so generated malware pages contain real threat actor names and working actor permalinks, and exposes the malware index through a Liquid-backed API wrapper. The generator now emits malware front matter through YAML serialization so quoted malware names remain parseable.

Also links malware mentions in threat actor `## Malware and Tools` sections back to generated malware pages at runtime, with validation that all 2,570 actor-page malware mentions resolve to existing malware pages.

[malware_actor_links_walkthrough.mp4](https://cursor.com/agents/bc-207aaea0-c1de-4833-8d7e-88c9af5f617f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmalware_actor_links_walkthrough.mp4)
[threat_actor_to_malware_links_walkthrough.mp4](https://cursor.com/agents/bc-207aaea0-c1de-4833-8d7e-88c9af5f617f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fthreat_actor_to_malware_links_walkthrough.mp4)

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New threat actor (non-breaking change)
- [ ] Documentation update
- [x] Code quality improvement

## Testing

- [x] `ruby -c scripts/generate-indexes.rb && ruby -c scripts/validate-content.rb`
- [x] `ruby scripts/generate-indexes.rb`
- [x] `ruby scripts/validate-content.rb`
- [x] `bash scripts/validate.sh`
- [x] Direct Ruby scan verified 2,570 malware actor links across 271 malware pages resolve to threat actor pages
- [x] Direct Ruby scan verified 2,570 threat actor malware mentions resolve to generated malware pages
- [x] Manual browser walkthrough searched Cobalt Strike, opened the malware detail page, and followed BRONZE EDGEWOOD to the actor page
- [x] Manual browser walkthrough opened VENOM SPIDER, clicked Cobalt Strike in Malware and Tools, and confirmed the malware page loaded with actor links

## Checklists

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass

## Source Attribution

For threat actor data changes, confirm source licensing:
- [ ] Data is CC0 licensed
- [ ] Data is CC BY 4.0 licensed
- [ ] I have permission to use this data
- [x] Data is from existing repository content with generated link corrections

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-207aaea0-c1de-4833-8d7e-88c9af5f617f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-207aaea0-c1de-4833-8d7e-88c9af5f617f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

