### PR TITLE
Add Russian APT Tool Matrix importer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,7 @@ data/imports/bushido-breach-reports/*
 !data/imports/ransomware-tool-matrix/
 data/imports/ransomware-tool-matrix/*
 !data/imports/ransomware-tool-matrix/mapping_overrides.yml
+!data/imports/russian-apt-tool-matrix/
+data/imports/russian-apt-tool-matrix/*
+!data/imports/russian-apt-tool-matrix/mapping_overrides.yml
 vendor/

--- a/_data/actors/apt0010.yml
+++ b/_data/actors/apt0010.yml
@@ -1,236 +1,97 @@
----
-name: Turla
-aliases:
-- BELUGASTURGEON
-- Group 88
-- IRON HUNTER
-- Krypton
-- Secret Blizzard
-- Snake
-- Turla
-- Venomous Bear
-- Waterbug
-- WhiteBear
-- VENOMOUS Bear
-- WRAITH
-- Uroburos
-- Pfinet
-- TAG_0530
-- KRYPTON
-- Hippo Team
-- Pacifier APT
-- Popeye
-- SIG23
-- MAKERSMARK
-- ATK13
-- G0010
-- ITG12
-- Blue Python
-- SUMMIT
-- UNC4210
-- UAC-0144
-- UAC-0024
-- UAC-0003
-- Turla Team
-- Турла
-- Turla Group
-description: 'Turla is a cyber espionage threat group that has been attributed to
-  Russia''s Federal Security Service (FSB).  They have compromised victims in over
-  50 countries since at least 2004, spanning a range of industries including government,
-  embassies, military, education, research and pharmaceutical companies. Turla is
-  known for conducting watering hole and spearphishing campaigns, and leveraging in-house
-  tools and malware, such as Uroburos.(Citation: Kaspersky Turla)(Citation: ESET Gazer
-  Aug 2017)(Citation: CrowdStrike VENOMOUS BEAR)(Citation: ESET Turla Mosquito Jan
-  2018)(Citation: Joint Cybersecurity Advisory AA23-129A Snake Malware May 2023)'
+name: "Turla"
+aliases: ["BELUGASTURGEON","Group 88","IRON HUNTER","Krypton","Secret Blizzard","Snake","Turla","Venomous Bear","Waterbug","WhiteBear","VENOMOUS Bear","WRAITH","Uroburos","Pfinet","TAG_0530","KRYPTON","Hippo Team","Pacifier APT","Popeye","SIG23","MAKERSMARK","ATK13","G0010","ITG12","Blue Python","SUMMIT","UNC4210","UAC-0144","UAC-0024","UAC-0003","Turla Team","Турла","Turla Group"]
+description: "Turla is a cyber espionage threat group that has been attributed to Russia's Federal Security Service (FSB).  They have compromised victims in over 50 countries since at least 2004, spanning a range of industries including government, embassies, military, education, research and pharmaceutical companies. Turla is known for conducting watering hole and spearphishing campaigns, and leveraging in-house tools and malware, such as Uroburos.(Citation: Kaspersky Turla)(Citation: ESET Gazer Aug 2017)(Citation: CrowdStrike VENOMOUS BEAR)(Citation: ESET Turla Mosquito Jan 2018)(Citation: Joint Cybersecurity Advisory AA23-129A Snake Malware May 2023)"
 url: "/apt0010"
-country: Russia
-sector_focus:
-- Government, Administration
-- Education
-- Electric
-- Energy
-- Health
-- Government
-- Military
-targeted_victims:
-- France
-- Romania
-- Kazakhstan
-- Poland
-- Tajikistan
-- Russia
-- United States
-- Saudi Arabia
-- Germany
-- India
-- Belarus
-- Netherlands
-- Iran
-- Uzbekistan
-- Iraq
-incident_type: Espionage
-first_seen: '2014'
-last_activity: '2019'
-risk_level: High
-external_id: G0010
-external_url: https://attack.mitre.org/groups/G0010
-mitre_id: G0010
-mitre_url: https://attack.mitre.org/groups/G0010
-source_name: Malpedia (Fraunhofer FKIE)
-source_attribution: "© The MITRE Corporation. This work is reproduced and distributed
-  with the permission of The MITRE Corporation."
-source_record_url: https://malpedia.caad.fkie.fraunhofer.de/actor/turla
-source_license: CC BY-NC-SA 3.0
-source_license_url: https://malpedia.caad.fkie.fraunhofer.de/legal
-operations:
-- Satellite Turla
-- Epic Turla
-- The 'Penquin' Turla
-- Witchcoven
-- RUAG hack
-- Mosquito
-- Moonlight Maze
-malware:
-- PowerDuke
-- POWERSTATS
-- Power Loader
-- POWERSOURCE
-- China Chopper
-- Archelaus Beta
-- PowerRAT
-- CrossRat
-- CyberAzov
-- Unidentified ASP 001 (Webshell)
-- Penquin Turla
-- KopiLuwak
-- MiniJS
-- HTML5 Encoding
-- Maintools.js
-- Uroburos
-- DeliveryCheck
-- LunarMail
-- NetFlash
-- Neuron
-- QUIETCANARY
-- Pelmeni
-- TwoDash
-- TwoFace
-- Agent.BTZ
-- ApolloShadow
-- Cobra Carbon System
-- ComLook
-- Crutch
-- Gazer
-- KSL0T
-- LightNeuron
-- MiniPocket
-- Mosquito
-- Nautilus
-- NewPass
-- Outlook Backdoor
-- PowerShellRunner
-- Satellite Turla
-- Skipper
-- TinyTurla
-- TinyTurlaNG
-- TurlaRPC
-- Turla SilentMoon
-- Wipbot
-- Kazuar
-- systeminfo
-- net
-- tasklist
-- gpresult
-- wce
-- pwdump
-- Turla
-- Tavdig
-- Agent.dne
-- AdobeARM
-- ATI-Agent
-- MiniDionis
-- WhiteBear
+country: "Russia"
+sector_focus: ["Government, Administration","Education","Electric","Energy","Health","Government","Military"]
+targeted_victims: ["France","Romania","Kazakhstan","Poland","Tajikistan","Russia","United States","Saudi Arabia","Germany","India","Belarus","Netherlands","Iran","Uzbekistan","Iraq"]
+incident_type: "Espionage"
+first_seen: "2014"
+last_activity: "2019"
+last_updated: "2026-04-28"
+risk_level: "High"
+external_id: "G0010"
+external_url: "https://attack.mitre.org/groups/G0010"
+mitre_id: "G0010"
+mitre_url: "https://attack.mitre.org/groups/G0010"
+source_name: "Malpedia (Fraunhofer FKIE)"
+source_attribution: "© The MITRE Corporation. This work is reproduced and distributed with the permission of The MITRE Corporation."
+source_record_url: "https://malpedia.caad.fkie.fraunhofer.de/actor/turla"
+source_license: "CC BY-NC-SA 3.0"
+source_license_url: "https://malpedia.caad.fkie.fraunhofer.de/legal"
+operations: ["Satellite Turla","Epic Turla","The 'Penquin' Turla","Witchcoven","RUAG hack","Mosquito","Moonlight Maze"]
+malware: ["PowerDuke","POWERSTATS","Power Loader","POWERSOURCE","China Chopper","Archelaus Beta","PowerRAT","CrossRat","CyberAzov","Unidentified ASP 001 (Webshell)","Penquin Turla","KopiLuwak","MiniJS","HTML5 Encoding","Maintools.js","Uroburos","DeliveryCheck","LunarMail","NetFlash","Neuron","QUIETCANARY","Pelmeni","TwoDash","TwoFace","Agent.BTZ","ApolloShadow","Cobra Carbon System","ComLook","Crutch","Gazer","KSL0T","LightNeuron","MiniPocket","Mosquito","Nautilus","NewPass","Outlook Backdoor","PowerShellRunner","Satellite Turla","Skipper","TinyTurla","TinyTurlaNG","TurlaRPC","Turla SilentMoon","Wipbot","Kazuar","systeminfo","net","tasklist","gpresult","wce","pwdump","Turla","Tavdig","Agent.dne","AdobeARM","ATI-Agent","MiniDionis","WhiteBear"]
 provenance:
   apt_groups_operations:
-    matched_mitre_ids:
-    - G0010
-    sheet_id: 1H9_xaxQHpWaa4O_Son4Gx0YOIzlcBWMsdvePFX68EKU
-    source_dataset_url: https://apt.threattracking.com/
-    source_links:
-    - https://securelist.com/analysis/publications/65545/the-epic-turla-operation/
-    - https://securelist.com/blog/research/72081/satellite-turla-apt-command-and-control-in-the-sky/
-    - https://securelist.com/blog/research/67962/the-penquin-turla-2/
-    - https://www2.fireeye.com/rs/848-DID-242/images/rpt-witchcoven.pdf
-    - https://www.symantec.com/content/en/us/enterprise/media/security_response/whitepapers/waterbug-attack-group.pdf
-    - https://www.welivesecurity.com/2017/03/30/carbon-paper-peering-turlas-second-stage-backdoor/
-    - https://www.welivesecurity.com/2017/06/06/turlas-watering-hole-campaign-updated-firefox-extension-abusing-instagram/
-    - https://securelist.com/kopiluwak-a-new-javascript-payload-from-turla/77429/
-    - https://www.proofpoint.com/us/threat-insight/post/turla-apt-actor-refreshes-kopiluwak-javascript-backdoor-use-g20-themed-attack
-    - https://www.welivesecurity.com/2017/08/30/eset-research-cyberespionage-gazer/
-    - https://www.govcert.admin.ch/blog/22/technical-report-about-the-ruag-espionage-case
-    - http://www.sueddeutsche.de/digital/it-sicherheit-einbrechen-ausbreiten-abgreifen-1.3887843
-    - https://www.welivesecurity.com/2018/05/22/turla-mosquito-shift-towards-generic-tools/
-    - https://www.ncsc.gov.uk/alerts/turla-group-malware
-    - https://motherboard.vice.com/en_us/article/vvk83b/moonlight-maze-turla-link
-    - https://media.kasperskycontenthub.com/wp-content/uploads/sites/43/2018/03/07180251/Penquins_Moonlit_Maze_PDF_eng.pdf
-    - https://www.wired.com/2017/04/russian-hackers-used-backdoor-two-decades/
-    - https://www.crowdstrike.com/blog/meet-crowdstrikes-adversary-of-the-month-for-march-venomous-bear/
-    - https://www.symantec.com/blogs/threat-intelligence/waterbug-espionage-governments
-    - https://securelist.com/turla-renews-its-arsenal-with-topinambour/91687/
-    source_retrieved_at: '2026-04-26T22:14:32Z'
-    tab_name: russia
+    matched_mitre_ids: ["G0010"]
+    sheet_id: "1H9_xaxQHpWaa4O_Son4Gx0YOIzlcBWMsdvePFX68EKU"
+    source_dataset_url: "https://apt.threattracking.com/"
+    source_links: ["https://securelist.com/analysis/publications/65545/the-epic-turla-operation/","https://securelist.com/blog/research/72081/satellite-turla-apt-command-and-control-in-the-sky/","https://securelist.com/blog/research/67962/the-penquin-turla-2/","https://www2.fireeye.com/rs/848-DID-242/images/rpt-witchcoven.pdf","https://www.symantec.com/content/en/us/enterprise/media/security_response/whitepapers/waterbug-attack-group.pdf","https://www.welivesecurity.com/2017/03/30/carbon-paper-peering-turlas-second-stage-backdoor/","https://www.welivesecurity.com/2017/06/06/turlas-watering-hole-campaign-updated-firefox-extension-abusing-instagram/","https://securelist.com/kopiluwak-a-new-javascript-payload-from-turla/77429/","https://www.proofpoint.com/us/threat-insight/post/turla-apt-actor-refreshes-kopiluwak-javascript-backdoor-use-g20-themed-attack","https://www.welivesecurity.com/2017/08/30/eset-research-cyberespionage-gazer/","https://www.govcert.admin.ch/blog/22/technical-report-about-the-ruag-espionage-case","http://www.sueddeutsche.de/digital/it-sicherheit-einbrechen-ausbreiten-abgreifen-1.3887843","https://www.welivesecurity.com/2018/05/22/turla-mosquito-shift-towards-generic-tools/","https://www.ncsc.gov.uk/alerts/turla-group-malware","https://motherboard.vice.com/en_us/article/vvk83b/moonlight-maze-turla-link","https://media.kasperskycontenthub.com/wp-content/uploads/sites/43/2018/03/07180251/Penquins_Moonlit_Maze_PDF_eng.pdf","https://www.wired.com/2017/04/russian-hackers-used-backdoor-two-decades/","https://www.crowdstrike.com/blog/meet-crowdstrikes-adversary-of-the-month-for-march-venomous-bear/","https://www.symantec.com/blogs/threat-intelligence/waterbug-espionage-governments","https://securelist.com/turla-renews-its-arsenal-with-topinambour/91687/"]
+    source_retrieved_at: "2026-04-26T22:14:32Z"
+    tab_name: "russia"
   aptnotes:
-    earliest_report_year: '2014'
-    latest_report_year: '2019'
+    earliest_report_year: "2014"
+    latest_report_year: "2019"
     report_count: 14
-    sample_links:
-    - https://app.box.com/s/dokswmrkrxmipfmdpsvelnq18w4ypogw
-    - https://app.box.com/s/xmeq5ajvmzux1appt1qvd8wme7k13o63
-    - https://app.box.com/s/n9zt53c246ltmhhjkcfay9xq8mee09yo
-    - https://app.box.com/s/4n263mzodo4mb7jz1w3deidg9xuu2teh
-    - https://app.box.com/s/54kvbxp9nc0xtme1omd1xpxcckwm945g
-    - https://app.box.com/s/9rsegtgvnwe9n2lrk6ezxfv8mnpfhpk3
-    - https://app.box.com/s/sg4cyodukt7edmmba6bfikuiu1jgzv59
-    - https://app.box.com/s/5gfajyyz8firhnttdo72j0iz6uo4eo6q
-    - https://app.box.com/s/nrf432kfdk6kadkvbclgykekocn4pzzu
-    - https://app.box.com/s/xcu346jhiokohlj9300q6hif06swac57
-    - https://app.box.com/s/vmzqwqfrmtdjemtdaei60jqu5qrouwrt
-    - https://app.box.com/s/316mbg901wxjdarmtdlj6v4qv29a0ge8
-    - https://app.box.com/s/o72u9tsw4zifxmktac4oreizhlud67ga
-    - https://app.box.com/s/u5p5eae02amqr2n0zg7017cx43t1icwz
-    sample_titles:
-    - Uroburos Highly Complex Espionage Software With Russian Roots
-    - Snake Campaign & Cyber Espionage Toolkit
-    - Suspected Russian Spyware Turla Targets Europe, United States
-    - 'Snake In The Grass: Python-based Malware Used For Targeted Attacks'
-    - Tr-25 Analysis - Turla / PNet / Snake/ Uroburos
-    - 'The Epic Turla Operation: Solving Some Of The Mysteries Of Snake/Uroboros'
-    - 'The Uroburos Case: New Sophisticated Rat Identified'
-    - The 'Penquin' Turla
-    - The Waterbug Attack Group
-    - Pacifier APT
-    source_dataset_url: https://raw.githubusercontent.com/aptnotes/data/master/APTnotes.csv
-    source_repository: https://github.com/aptnotes/data
-    source_retrieved_at: '2026-04-26T22:14:32Z'
-    sources:
-    - BAE Systems
-    - Bitdefender
-    - Bluecoat
-    - CIRCL
-    - ESET
-    - Gdata
-    - Kaspersky
-    - NCSC
-    - Reuters
-    - Symantec
+    sample_links: ["https://app.box.com/s/dokswmrkrxmipfmdpsvelnq18w4ypogw","https://app.box.com/s/xmeq5ajvmzux1appt1qvd8wme7k13o63","https://app.box.com/s/n9zt53c246ltmhhjkcfay9xq8mee09yo","https://app.box.com/s/4n263mzodo4mb7jz1w3deidg9xuu2teh","https://app.box.com/s/54kvbxp9nc0xtme1omd1xpxcckwm945g","https://app.box.com/s/9rsegtgvnwe9n2lrk6ezxfv8mnpfhpk3","https://app.box.com/s/sg4cyodukt7edmmba6bfikuiu1jgzv59","https://app.box.com/s/5gfajyyz8firhnttdo72j0iz6uo4eo6q","https://app.box.com/s/nrf432kfdk6kadkvbclgykekocn4pzzu","https://app.box.com/s/xcu346jhiokohlj9300q6hif06swac57","https://app.box.com/s/vmzqwqfrmtdjemtdaei60jqu5qrouwrt","https://app.box.com/s/316mbg901wxjdarmtdlj6v4qv29a0ge8","https://app.box.com/s/o72u9tsw4zifxmktac4oreizhlud67ga","https://app.box.com/s/u5p5eae02amqr2n0zg7017cx43t1icwz"]
+    sample_titles: ["Uroburos Highly Complex Espionage Software With Russian Roots","Snake Campaign & Cyber Espionage Toolkit","Suspected Russian Spyware Turla Targets Europe, United States","Snake In The Grass: Python-based Malware Used For Targeted Attacks","Tr-25 Analysis - Turla / PNet / Snake/ Uroburos","The Epic Turla Operation: Solving Some Of The Mysteries Of Snake/Uroboros","The Uroburos Case: New Sophisticated Rat Identified","The 'Penquin' Turla","The Waterbug Attack Group","Pacifier APT"]
+    source_dataset_url: "https://raw.githubusercontent.com/aptnotes/data/master/APTnotes.csv"
+    source_repository: "https://github.com/aptnotes/data"
+    source_retrieved_at: "2026-04-26T22:14:32Z"
+    sources: ["BAE Systems","Bitdefender","Bluecoat","CIRCL","ESET","Gdata","Kaspersky","NCSC","Reuters","Symantec"]
   malpedia:
-    source_dataset_url: https://malpedia.caad.fkie.fraunhofer.de/api/get/actors
-    source_record_id: turla
-    source_record_url: https://malpedia.caad.fkie.fraunhofer.de/actor/turla
-    source_retrieved_at: '2026-04-26T22:14:32Z'
-    source_uuid: fa80877c-f509-4daf-8b62-20aba1635f68
+    source_dataset_url: "https://malpedia.caad.fkie.fraunhofer.de/api/get/actors"
+    source_record_id: "turla"
+    source_record_url: "https://malpedia.caad.fkie.fraunhofer.de/actor/turla"
+    source_retrieved_at: "2026-04-26T22:14:32Z"
+    source_uuid: "fa80877c-f509-4daf-8b62-20aba1635f68"
   mitre:
-    source_dataset_url: https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack.json
-    source_record_id: G0010
-    source_retrieved_at: '2026-04-26T05:24:31Z'
-source: MITRE ATT&CK
+    source_dataset_url: "https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack.json"
+    source_record_id: "G0010"
+    source_retrieved_at: "2026-04-26T05:24:31Z"
+  russian_apt_tool_matrix:
+    references:
+      - title: "web-assets.esetstatic.com"
+        url: "https://web-assets.esetstatic.com/wls/2020/05/ESET_Turla_ComRAT.pdf"
+        date: "15 June 2020"
+        source_file: "GroupProfiles/Turla.md"
+      - title: "web-assets.esetstatic.com"
+        url: "https://web-assets.esetstatic.com/wls/2018/08/Eset-Turla-Outlook-Backdoor.pdf"
+        date: "17 August 2018"
+        source_file: "GroupProfiles/Turla.md"
+      - title: "www.welivesecurity.com"
+        url: "https://www.welivesecurity.com/2020/12/02/turla-crutch-keeping-back-door-open/"
+        date: "2 December 2020"
+        source_file: "GroupProfiles/Turla.md"
+      - title: "symantec-enterprise-blogs.security.com"
+        url: "https://symantec-enterprise-blogs.security.com/threat-intelligence/waterbug-espionage-governments"
+        date: "20 June 2019"
+        source_file: "GroupProfiles/Turla.md"
+      - title: "blog.talosintelligence.com"
+        url: "https://blog.talosintelligence.com/tinyturla-full-kill-chain/"
+        date: "21 March 2024"
+        source_file: "GroupProfiles/Turla.md"
+      - title: "www.welivesecurity.com"
+        url: "https://www.welivesecurity.com/2018/05/22/turla-mosquito-shift-towards-generic-tools/"
+        date: "22 May 2018"
+        source_file: "GroupProfiles/Turla.md"
+      - title: "www.cisa.gov"
+        url: "https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-129a"
+        date: "9 May 2023"
+        source_file: "GroupProfiles/Turla.md"
+    source_attribution: "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence."
+    source_dataset_url: "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1"
+    source_files: ["GroupProfiles/Turla.md","Other/ThreatIntelligence.md","Tools/CredentialTheft.md","Tools/DefenseEvasion.md","Tools/Discovery.md","Tools/Exfiltration.md","Tools/LOLBAS.md","Tools/Offsec.md","Tools/RMM-Tools.md"]
+    source_label: "Turla"
+    source_repository: "https://github.com/BushidoUK/Russian-APT-Tool-Matrix"
+    source_retrieved_at: "2026-04-28T02:07:35Z"
+    tools_by_category:
+      Credential Theft: ["Mimikatz"]
+      Defense Evasion: ["PowerShellRunner","VirtualBox Driver"]
+      Discovery: ["NBTScan","SScan"]
+      Exfiltration: ["4Shared","Dropbox","GMX","Gmail","OneDrive","VFEmail"]
+      LOLBAS: ["PsExec"]
+      Networking: ["Chisel"]
+      OffSec: ["Evil-WinRM","Metapsloit","Metasploit","PowerShell Empire","PowerSploit"]
+      RMM Tools: ["IntelliAdmin"]
+source: "MITRE ATT&CK"

--- a/_data/actors/apt0035.yml
+++ b/_data/actors/apt0035.yml
@@ -2,6 +2,7 @@ name: "Dragonfly"
 aliases: ["Berserk Bear","BROMINE","Crouching Yeti","Dragonfly","DYMALLOY","Energetic Bear","Ghost Blizzard","IRON LIBERTY","TEMP.Isotope","TG-4192"]
 description: "Dragonfly is a cyber espionage group that has been attributed to Russia's Federal Security Service (FSB) Center 16.(Citation: DOJ Russia Targeting Critical Infrastructure March 2022)(Citation: UK GOV FSB Factsheet April 2022) Active since at least 2010, Dragonfly has targeted defense and aviation companies, government entities, companies related to industrial control systems, and critical infrastructure sectors worldwide through supply chain, spearphishing, and drive-by compromise attacks.(Citation: Symantec Dragonfly)(Citation: Secureworks IRON LIBERTY July 2019)(Citation: Symantec Dragonfly Sept 2017)(Citation: Fortune Dragonfly 2.0 Sept 2017)(Citation: Gigamon Berserk Bear October 2021)(Citation: CISA AA20-296A Berserk Bear December 2020)(Citation: Symantec Dragonfly 2.0 October 2017)"
 url: "/apt0035"
+last_updated: "2026-04-28"
 external_id: "G0035"
 external_url: "https://attack.mitre.org/groups/G0035"
 mitre_id: "G0035"
@@ -12,4 +13,35 @@ provenance:
     source_dataset_url: "https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack.json"
     source_record_id: "G0035"
     source_retrieved_at: "2026-04-26T05:24:31Z"
+  russian_apt_tool_matrix:
+    references:
+      - title: "www.cisa.gov"
+        url: "https://www.cisa.gov/news-events/alerts/2018/03/15/russian-government-cyber-activity-targeting-energy-and-other-critical-infrastructure-sectors"
+        date: "16 March 2018"
+        source_file: "GroupProfiles/BERSERKBEAR.md"
+      - title: "symantec-enterprise-blogs.security.com"
+        url: "https://symantec-enterprise-blogs.security.com/threat-intelligence/dragonfly-energy-sector-cyber-attacks"
+        date: "20 October 2017"
+        source_file: "GroupProfiles/BERSERKBEAR.md"
+      - title: "www.secureworks.com"
+        url: "https://www.secureworks.com/research/resurgent-iron-liberty-targeting-energy-sector"
+        date: "24 July 2019"
+        source_file: "GroupProfiles/BERSERKBEAR.md"
+      - title: "www.gov.uk"
+        url: "https://www.gov.uk/government/news/uk-exposes-russian-spy-agency-behind-cyber-incidents"
+        date: "24 March 2022"
+        source_file: "GroupProfiles/BERSERKBEAR.md"
+    source_attribution: "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence."
+    source_dataset_url: "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1"
+    source_files: ["GroupProfiles/BERSERKBEAR.md","Other/ThreatIntelligence.md","Tools/CredentialTheft.md","Tools/Discovery.md","Tools/LOLBAS.md","Tools/Networking.md","Tools/Offsec.md","Tools/RMM-Tools.md"]
+    source_label: "BERSERK BEAR"
+    source_repository: "https://github.com/BushidoUK/Russian-APT-Tool-Matrix"
+    source_retrieved_at: "2026-04-28T02:07:35Z"
+    tools_by_category:
+      Credential Theft: ["Mimikatz","ProcDump"]
+      Discovery: ["Angry IP Scanner"]
+      LOLBAS: ["BITSAdmin","PsExec"]
+      Networking: ["FortiClient"]
+      OffSec: ["CrackMapExec","Hydra","Impacket","Phishery"]
+      RMM Tools: ["TeamViewer"]
 source: "MITRE ATT&CK"

--- a/_data/actors/apt0047.yml
+++ b/_data/actors/apt0047.yml
@@ -1,44 +1,46 @@
----
-name: Gamaredon Group
-aliases:
-- ACTINIUM
-- Actinium
-- Aqua Blizzard
-- Armageddon
-- Blue Otso
-- BlueAlpha
-- DEV-0157
-- G0047
-- Gamaredon Group
-- IRON TILDEN
-- Primitive Bear
-- PRIMITIVE BEAR
-- Shuckworm
-- Trident Ursa
-- UAC-0010
-- Winterflounder
-description: |-
-  Gamaredon Group is a suspected Russian cyber espionage group that has targeted military, law enforcement, judiciary, non-profit, and non-governmental organizations in Ukraine since at least 2013. The name Gamaredon Group derives from a misspelling of the word "Armageddon," found in early campaigns.(Citation: Palo Alto Gamaredon Feb 2017)(Citation: TrendMicro Gamaredon April 2020)(Citation: ESET Gamaredon June 2020)(Citation: Symantec Shuckworm January 2022)(Citation: Microsoft Actinium February 2022)
-
-  In November 2021, the Ukrainian government publicly attributed Gamaredon Group to Russia’s Federal Security Service (FSB) Center 18, an assessment later supported by multiple independent cybersecurity researchers. (Citation: Bleepingcomputer Gamardeon FSB November 2021)(Citation: Microsoft Actinium February 2022)
+name: "Gamaredon Group"
+aliases: ["ACTINIUM","Actinium","Aqua Blizzard","Armageddon","Blue Otso","BlueAlpha","DEV-0157","G0047","Gamaredon Group","IRON TILDEN","Primitive Bear","PRIMITIVE BEAR","Shuckworm","Trident Ursa","UAC-0010","Winterflounder"]
+description: "Gamaredon Group is a suspected Russian cyber espionage group that has targeted military, law enforcement, judiciary, non-profit, and non-governmental organizations in Ukraine since at least 2013. The name Gamaredon Group derives from a misspelling of the word \"Armageddon,\" found in early campaigns.(Citation: Palo Alto Gamaredon Feb 2017)(Citation: TrendMicro Gamaredon April 2020)(Citation: ESET Gamaredon June 2020)(Citation: Symantec Shuckworm January 2022)(Citation: Microsoft Actinium February 2022)\n\nIn November 2021, the Ukrainian government publicly attributed Gamaredon Group to Russia’s Federal Security Service (FSB) Center 18, an assessment later supported by multiple independent cybersecurity researchers. (Citation: Bleepingcomputer Gamardeon FSB November 2021)(Citation: Microsoft Actinium February 2022)"
 url: "/apt0047"
-country: Russia
-sector_focus:
-- Government
-targeted_victims:
-- Ukraine
-- Germany
-external_id: G0047
-external_url: https://attack.mitre.org/groups/G0047
-mitre_id: G0047
-mitre_url: https://attack.mitre.org/groups/G0047
-source_attribution: "© The MITRE Corporation. This work is reproduced and distributed
-  with the permission of The MITRE Corporation."
-malware:
-- Archelaus Beta
+country: "Russia"
+sector_focus: ["Government"]
+targeted_victims: ["Ukraine","Germany"]
+last_updated: "2026-04-28"
+external_id: "G0047"
+external_url: "https://attack.mitre.org/groups/G0047"
+mitre_id: "G0047"
+mitre_url: "https://attack.mitre.org/groups/G0047"
+source_attribution: "© The MITRE Corporation. This work is reproduced and distributed with the permission of The MITRE Corporation."
+malware: ["Archelaus Beta"]
 provenance:
   mitre:
-    source_dataset_url: https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack.json
-    source_record_id: G0047
-    source_retrieved_at: '2026-04-26T07:05:44Z'
-source: MITRE ATT&CK
+    source_dataset_url: "https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack.json"
+    source_record_id: "G0047"
+    source_retrieved_at: "2026-04-26T07:05:44Z"
+  russian_apt_tool_matrix:
+    references:
+      - title: "harfanglab.io"
+        url: "https://harfanglab.io/insidethelab/gamaredons-pterolnk-analysis/"
+        date: "16 April 2025"
+        source_file: "Other/ThreatIntelligence.md"
+      - title: "www.welivesecurity.com"
+        url: "https://www.welivesecurity.com/en/eset-research/cyberespionage-gamaredon-way-analysis-toolset-used-spy-ukraine-2022-2023"
+        date: "26 September 2024"
+        source_file: "GroupProfiles/Gamaredon.md"
+      - title: "ssu.gov.ua"
+        url: "https://ssu.gov.ua/uploads/files/DKIB/Technical%20report%20Armagedon.pdf"
+        date: "4 November 2021"
+        source_file: "GroupProfiles/Gamaredon.md"
+    source_attribution: "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence."
+    source_dataset_url: "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1"
+    source_files: ["GroupProfiles/Gamaredon.md","Other/ThreatIntelligence.md","Tools/CredentialTheft.md","Tools/Exfiltration.md","Tools/LOLBAS.md","Tools/Networking.md","Tools/RMM-Tools.md"]
+    source_label: "Gamaredon"
+    source_repository: "https://github.com/BushidoUK/Russian-APT-Tool-Matrix"
+    source_retrieved_at: "2026-04-28T02:07:35Z"
+    tools_by_category:
+      Credential Theft: ["Mimikatz"]
+      Exfiltration: ["Rclone","Telegram"]
+      LOLBAS: ["PsExec"]
+      Networking: ["Cloudflared","Ngrok","telegra[.]ph","teletype[.]in","trycloudflare[.]com"]
+      RMM Tools: ["Remote Manipulator System (RMS)","UltraVNC"]
+source: "MITRE ATT&CK"

--- a/_data/actors/apt1003.yml
+++ b/_data/actors/apt1003.yml
@@ -2,6 +2,7 @@ name: "Ember Bear"
 aliases: ["Ember Bear","UNC2589","Bleeding Bear","DEV-0586","Cadet Blizzard","Frozenvista","UAC-0056"]
 description: "Ember Bear is a Russian state-sponsored cyber espionage group that has been active since at least 2020, linked to Russia's General Staff Main Intelligence Directorate (GRU) 161st Specialist Training Center (Unit 29155).(Citation: CISA GRU29155 2024) Ember Bear has primarily focused operations against Ukrainian government and telecommunication entities, but has also operated against critical infrastructure entities in Europe and the Americas.(Citation: Cadet Blizzard emerges as novel threat actor) Ember Bear conducted the WhisperGate destructive wiper attacks against Ukraine in early 2022.(Citation: CrowdStrike Ember Bear Profile March 2022)(Citation: Mandiant UNC2589 March 2022)(Citation: CISA GRU29155 2024) There is some confusion as to whether Ember Bear overlaps with another Russian-linked entity referred to as Saint Bear. At present available evidence strongly suggests these are distinct activities with different behavioral profiles.(Citation: Cadet Blizzard emerges as novel threat actor)(Citation: Palo Alto Unit 42 OutSteel SaintBot February 2022 )"
 url: "/apt1003"
+last_updated: "2026-04-28"
 external_id: "G1003"
 external_url: "https://attack.mitre.org/groups/G1003"
 mitre_id: "G1003"
@@ -12,4 +13,22 @@ provenance:
     source_dataset_url: "https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack.json"
     source_record_id: "G1003"
     source_retrieved_at: "2026-04-26T05:01:37Z"
+  russian_apt_tool_matrix:
+    references:
+      - title: "www.cisa.gov"
+        url: "https://www.cisa.gov/news-events/cybersecurity-advisories/aa24-249a"
+        date: "5 September 2024"
+        source_file: "GroupProfiles/EMBERBEAR.md"
+    source_attribution: "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence."
+    source_dataset_url: "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1"
+    source_files: ["GroupProfiles/EMBERBEAR.md","Other/ThreatIntelligence.md","Tools/Discovery.md","Tools/Exfiltration.md","Tools/LOLBAS.md","Tools/Networking.md","Tools/Offsec.md"]
+    source_label: "EMBER BEAR"
+    source_repository: "https://github.com/BushidoUK/Russian-APT-Tool-Matrix"
+    source_retrieved_at: "2026-04-28T02:07:35Z"
+    tools_by_category:
+      Discovery: ["Acunetix","Adminer","Amass","Bloodhound","Droopescan","JoomScan","LdapDomainDump","Masscan","Nmap","WPScan"]
+      Exfiltration: ["MEGA","Rclone"]
+      LOLBAS: ["PsExec"]
+      Networking: ["GOST","Iodine","ProxyChains","ReGeorg","dnscat2"]
+      OffSec: ["CrackMapExec","Impacket","LinPEAS","Metasploit","Meterpreter","NetCat","PAS Web Shell","Responder","WSO Web Shell"]
 source: "MITRE ATT&CK"

--- a/_data/actors/apt28.yml
+++ b/_data/actors/apt28.yml
@@ -1,214 +1,100 @@
----
-name: APT28
-aliases:
-- APT-C-20
-- APT28
-- ATK5
-- Blue Athena
-- BlueDelta
-- Fancy Bear
-- FANCY BEAR
-- Fighting Ursa
-- Forest Blizzard
-- FROZENLAKE
-- G0007
-- Grizzly Steppe
-- Group 74
-- GruesomeLarch
-- IRON TWILIGHT
-- ITG05
-- Pawn Storm
-- Sednit
-- SIG40
-- SNAKEMACKEREL
-- Sofacy
-- Sofacy Group
-- STRONTIUM
-- Swallowtail
-- T-APT-12
-- TA422
-- TG-4127
-- Threat Group-4127
-- Tsar Team
-- UAC-0001
-- UAC-0028
-- APT 28
-- TsarTeam
-- Group-4127
-- Grey-Cloud
-description: "APT28 is a threat group that has been attributed to Russia's General
-  Staff Main Intelligence Directorate (GRU) 85th Main Special Service Center (GTsSS)
-  military unit 26165.(Citation: NSA/FBI Drovorub August 2020)(Citation: Cybersecurity
-  Advisory GRU Brute Force Campaign July 2021) This group has been active since at
-  least 2004.(Citation: DOJ GRU Indictment Jul 2018)(Citation: Ars Technica GRU indictment
-  Jul 2018)(Citation: Crowdstrike DNC June 2016)(Citation: FireEye APT28)(Citation:
-  SecureWorks TG-4127)(Citation: FireEye APT28 January 2017)(Citation: GRIZZLY STEPPE
-  JAR)(Citation: Sofacy DealersChoice)(Citation: Palo Alto Sofacy 06-2018)(Citation:
-  Symantec APT28 Oct 2018)(Citation: ESET Zebrocy May 2019)\n\nAPT28 reportedly compromised
-  the Hillary Clinton campaign, the Democratic National Committee, and the Democratic
-  Congressional Campaign Committee in 2016 in an attempt to interfere with the U.S.
-  presidential election.(Citation: Crowdstrike DNC June 2016) In 2018, the US indicted
-  five GRU Unit 26165 officers associated with APT28 for cyber operations (including
-  close-access operations) conducted between 2014 and 2018 against the World Anti-Doping
-  Agency (WADA), the US Anti-Doping Agency, a US nuclear facility, the Organization
-  for the Prohibition of Chemical Weapons (OPCW), the Spiez Swiss Chemicals Laboratory,
-  and other organizations.(Citation: US District Court Indictment GRU Oct 2018) Some
-  of these were conducted with the assistance of GRU Unit 74455, which is also referred
-  to as Sandworm Team. "
+name: "APT28"
+aliases: ["APT-C-20","APT28","ATK5","Blue Athena","BlueDelta","Fancy Bear","FANCY BEAR","Fighting Ursa","Forest Blizzard","FROZENLAKE","G0007","Grizzly Steppe","Group 74","GruesomeLarch","IRON TWILIGHT","ITG05","Pawn Storm","Sednit","SIG40","SNAKEMACKEREL","Sofacy","Sofacy Group","STRONTIUM","Swallowtail","T-APT-12","TA422","TG-4127","Threat Group-4127","Tsar Team","UAC-0001","UAC-0028","APT 28","TsarTeam","Group-4127","Grey-Cloud"]
+description: "APT28 is a threat group that has been attributed to Russia's General Staff Main Intelligence Directorate (GRU) 85th Main Special Service Center (GTsSS) military unit 26165.(Citation: NSA/FBI Drovorub August 2020)(Citation: Cybersecurity Advisory GRU Brute Force Campaign July 2021) This group has been active since at least 2004.(Citation: DOJ GRU Indictment Jul 2018)(Citation: Ars Technica GRU indictment Jul 2018)(Citation: Crowdstrike DNC June 2016)(Citation: FireEye APT28)(Citation: SecureWorks TG-4127)(Citation: FireEye APT28 January 2017)(Citation: GRIZZLY STEPPE JAR)(Citation: Sofacy DealersChoice)(Citation: Palo Alto Sofacy 06-2018)(Citation: Symantec APT28 Oct 2018)(Citation: ESET Zebrocy May 2019)\n\nAPT28 reportedly compromised the Hillary Clinton campaign, the Democratic National Committee, and the Democratic Congressional Campaign Committee in 2016 in an attempt to interfere with the U.S. presidential election.(Citation: Crowdstrike DNC June 2016) In 2018, the US indicted five GRU Unit 26165 officers associated with APT28 for cyber operations (including close-access operations) conducted between 2014 and 2018 against the World Anti-Doping Agency (WADA), the US Anti-Doping Agency, a US nuclear facility, the Organization for the Prohibition of Chemical Weapons (OPCW), the Spiez Swiss Chemicals Laboratory, and other organizations.(Citation: US District Court Indictment GRU Oct 2018) Some of these were conducted with the assistance of GRU Unit 74455, which is also referred to as Sandworm Team. "
 url: "/apt28"
-country: Russia
-sector_focus:
-- Government
-- Military
-- Media
-- Government, Administration
-- Security Service
-targeted_victims:
-- Georgia
-- France
-- Jordan
-- United States
-- Hungary
-- World Anti-Doping Agency
-- Armenia
-- Tajikistan
-- Japan
-- NATO
-- Ukraine
-- Belgium
-- Pakistan
-- Asia Pacific Economic Cooperation
-- International Association of Athletics Federations
-- Turkey
-- Mongolia
-- OSCE
-- United Kingdom
-- Germany
-- Poland
-- European Commission
-- Afghanistan
-- Kazakhstan
-- China
-incident_type: Espionage
-first_seen: '2007'
-last_activity: '2024'
-last_updated: '2026-04-27'
-risk_level: High
-external_id: G0007
-external_url: https://attack.mitre.org/groups/G0007
-mitre_id: G0007
-mitre_url: https://attack.mitre.org/groups/G0007
-source_name: Malpedia (Fraunhofer FKIE)
-source_attribution: "© The MITRE Corporation. This work is reproduced and distributed
-  with the permission of The MITRE Corporation."
-source_record_url: https://malpedia.caad.fkie.fraunhofer.de/actor/apt28
-source_license: CC BY-NC-SA 3.0
-source_license_url: https://malpedia.caad.fkie.fraunhofer.de/legal
-malware:
-- CyberGate
-- Cyber Eye RAT
-- X-Agent
-- Komplex
-- ArguePatch
-- Cannon
-- DriveOcean
-- Unidentified 114 (APT28 InfoStealer)
-- XP PrivEsc (CVE-2014-4076)
-- X-Tunnel (.NET)
-- Zebrocy (AutoIT)
-- LoJax
-- CredoMap
-- Mocky LNK
-- OCEANMAP
-- SpyPress
-- STEELHOOK
-- MASEPIE
-- LAMEHUG
-- CaddyWiper
-- Computrace
-- Coreshell
-- Downdelph
-- FusionDrive
-- GooseEgg
-- Graphite
-- Koadic
-- OLDBAIT
-- PocoDown
-- Sedreco
-- Seduploader
-- Unidentified 078 (Zebrocy Nim Loader?)
-- Zebrocy
-- GONEPOSTAL
-- BadPaw
-- BEARDSHELL
-- SLIMAGENT
-- XTunnel
-- Unidentified JS 007 (Zimbra Stealer)
-- PixyNetLoader
+country: "Russia"
+sector_focus: ["Government","Military","Media","Government, Administration","Security Service"]
+targeted_victims: ["Georgia","France","Jordan","United States","Hungary","World Anti-Doping Agency","Armenia","Tajikistan","Japan","NATO","Ukraine","Belgium","Pakistan","Asia Pacific Economic Cooperation","International Association of Athletics Federations","Turkey","Mongolia","OSCE","United Kingdom","Germany","Poland","European Commission","Afghanistan","Kazakhstan","China"]
+incident_type: "Espionage"
+first_seen: "2007"
+last_activity: "2024"
+last_updated: "2026-04-28"
+risk_level: "High"
+external_id: "G0007"
+external_url: "https://attack.mitre.org/groups/G0007"
+mitre_id: "G0007"
+mitre_url: "https://attack.mitre.org/groups/G0007"
+source_name: "Malpedia (Fraunhofer FKIE)"
+source_attribution: "© The MITRE Corporation. This work is reproduced and distributed with the permission of The MITRE Corporation."
+source_record_url: "https://malpedia.caad.fkie.fraunhofer.de/actor/apt28"
+source_license: "CC BY-NC-SA 3.0"
+source_license_url: "https://malpedia.caad.fkie.fraunhofer.de/legal"
+malware: ["CyberGate","Cyber Eye RAT","X-Agent","Komplex","ArguePatch","Cannon","DriveOcean","Unidentified 114 (APT28 InfoStealer)","XP PrivEsc (CVE-2014-4076)","X-Tunnel (.NET)","Zebrocy (AutoIT)","LoJax","CredoMap","Mocky LNK","OCEANMAP","SpyPress","STEELHOOK","MASEPIE","LAMEHUG","CaddyWiper","Computrace","Coreshell","Downdelph","FusionDrive","GooseEgg","Graphite","Koadic","OLDBAIT","PocoDown","Sedreco","Seduploader","Unidentified 078 (Zebrocy Nim Loader?)","Zebrocy","GONEPOSTAL","BadPaw","BEARDSHELL","SLIMAGENT","XTunnel","Unidentified JS 007 (Zimbra Stealer)","PixyNetLoader"]
 provenance:
   aptnotes:
-    earliest_report_year: '2014'
-    latest_report_year: '2023'
+    earliest_report_year: "2014"
+    latest_report_year: "2023"
     report_count: 26
-    sample_links:
-    - https://app.box.com/s/th78b3w9bhr1cpdtn9gmmm9v7j2vuq47
-    - https://app.box.com/s/t2flymgu0ct5s3z487oedaq8dycsge77
-    - https://app.box.com/s/2e7s0j3cuuswoplyvaqdz4kdudvvr7x7
-    - https://app.box.com/s/9b7dfetwel6ywbcfai2wa0ja20cym721
-    - https://app.box.com/s/oj4sr8vifeb03qe51newafin81tu8poy
-    - https://app.box.com/s/dm3fbeb7hl95ilno014ftskoc1vi7n1r
-    - https://app.box.com/s/g55oxdd3q63hyngbjm4fbipfct94wrye
-    - https://app.box.com/s/2x3mrik225skob8rxd50rp63wlq0fp6v
-    - https://app.box.com/s/49rs6u4cyq43khamdah90y9zyacjzmbr
-    - https://app.box.com/s/uy6iv3fj7akwzrj9zq1gv403b35twaoy
-    - https://app.box.com/s/jfku9mhjnf150uokw2owfxy0isj3pi28
-    - https://app.box.com/s/2y2p7im0bp3o5myvi5s9cxfchddn2zbd
-    - https://app.box.com/s/w1qrcz1z9bx2dwt4gegv0h940ex35hlt
-    - https://app.box.com/s/c7oz0zci5gxsbgnucxwah82bfdj0boe0
-    - https://app.box.com/s/lmaensc7vzdugsy1nsh4bwligl07q53b
-    - https://app.box.com/s/p4ywd9iqr5fr48nbz5o0nfwwgjkq5itk
-    - https://app.box.com/s/7u92nzu48zg6kq0pmtlh9pj8p6jmjmrt
-    - https://app.box.com/s/77t5ropot0e1yy0r1i5g8s9bsvvnq6t3
-    - https://app.box.com/s/8lj785rl608lsmf80bwvtuxb7b9mscxy
-    - https://app.box.com/s/py4k1124p7hqacfb6dlkghvsh5xte2zw
-    sample_titles:
-    - Tactical Intelligence Bulletin Sofacy Phishing
-    - Operation Pawn Storm Using Decoys To Evade Detection
-    - 'Apt28: A Window Into Russia''s Cyber Espionage Operations'
-    - 'Pawn Storm Update: Ios Espionage App Found'
-    - 'Operation Russiandoll: Adobe & Windows ZeroDay Exploits Likely leveraged By
-      Russia''s APT28'
-    - Sofacy II_ Same Sofacy, Different Day
-    - 'APT28 Targets Financial Markets: Zero Day Hashes Released'
-    - 'A Look Into Fysbis: Sofacy''s Linux Backdoor'
-    - New Sofacy Attacks Against US Government Agency
-    - Threat Group-4127 Targets Hillary Clinton Presidential Campaign
-    source_dataset_url: https://raw.githubusercontent.com/aptnotes/data/master/APTnotes.csv
-    source_repository: https://github.com/aptnotes/data
-    source_retrieved_at: '2026-04-26T22:14:32Z'
-    sources:
-    - Bitdefender
-    - CERT-UA
-    - Crowdstrike
-    - Dell Secureworks
-    - ESET
-    - FireEye
-    - IBM
-    - McAfee
-    - PWC
-    - Palo Alto
-    - Palo Alto Networks
-    - Secureworks
-    - Trend Micro
-    - root9b
-    - tr1adx
+    sample_links: ["https://app.box.com/s/th78b3w9bhr1cpdtn9gmmm9v7j2vuq47","https://app.box.com/s/t2flymgu0ct5s3z487oedaq8dycsge77","https://app.box.com/s/2e7s0j3cuuswoplyvaqdz4kdudvvr7x7","https://app.box.com/s/9b7dfetwel6ywbcfai2wa0ja20cym721","https://app.box.com/s/oj4sr8vifeb03qe51newafin81tu8poy","https://app.box.com/s/dm3fbeb7hl95ilno014ftskoc1vi7n1r","https://app.box.com/s/g55oxdd3q63hyngbjm4fbipfct94wrye","https://app.box.com/s/2x3mrik225skob8rxd50rp63wlq0fp6v","https://app.box.com/s/49rs6u4cyq43khamdah90y9zyacjzmbr","https://app.box.com/s/uy6iv3fj7akwzrj9zq1gv403b35twaoy","https://app.box.com/s/jfku9mhjnf150uokw2owfxy0isj3pi28","https://app.box.com/s/2y2p7im0bp3o5myvi5s9cxfchddn2zbd","https://app.box.com/s/w1qrcz1z9bx2dwt4gegv0h940ex35hlt","https://app.box.com/s/c7oz0zci5gxsbgnucxwah82bfdj0boe0","https://app.box.com/s/lmaensc7vzdugsy1nsh4bwligl07q53b","https://app.box.com/s/p4ywd9iqr5fr48nbz5o0nfwwgjkq5itk","https://app.box.com/s/7u92nzu48zg6kq0pmtlh9pj8p6jmjmrt","https://app.box.com/s/77t5ropot0e1yy0r1i5g8s9bsvvnq6t3","https://app.box.com/s/8lj785rl608lsmf80bwvtuxb7b9mscxy","https://app.box.com/s/py4k1124p7hqacfb6dlkghvsh5xte2zw"]
+    sample_titles: ["Tactical Intelligence Bulletin Sofacy Phishing","Operation Pawn Storm Using Decoys To Evade Detection","Apt28: A Window Into Russia's Cyber Espionage Operations","Pawn Storm Update: Ios Espionage App Found","Operation Russiandoll: Adobe & Windows ZeroDay Exploits Likely leveraged By Russia's APT28","Sofacy II_ Same Sofacy, Different Day","APT28 Targets Financial Markets: Zero Day Hashes Released","A Look Into Fysbis: Sofacy's Linux Backdoor","New Sofacy Attacks Against US Government Agency","Threat Group-4127 Targets Hillary Clinton Presidential Campaign"]
+    source_dataset_url: "https://raw.githubusercontent.com/aptnotes/data/master/APTnotes.csv"
+    source_repository: "https://github.com/aptnotes/data"
+    source_retrieved_at: "2026-04-26T22:14:32Z"
+    sources: ["Bitdefender","CERT-UA","Crowdstrike","Dell Secureworks","ESET","FireEye","IBM","McAfee","PWC","Palo Alto","Palo Alto Networks","Secureworks","Trend Micro","root9b","tr1adx"]
   malpedia:
-    source_dataset_url: https://malpedia.caad.fkie.fraunhofer.de/api/get/actors
-    source_record_id: apt28
-    source_record_url: https://malpedia.caad.fkie.fraunhofer.de/actor/apt28
-    source_retrieved_at: '2026-04-26T22:14:32Z'
-    source_uuid: 5b4ee3ea-eee3-4c8e-8323-85ae32658754
+    source_dataset_url: "https://malpedia.caad.fkie.fraunhofer.de/api/get/actors"
+    source_record_id: "apt28"
+    source_record_url: "https://malpedia.caad.fkie.fraunhofer.de/actor/apt28"
+    source_retrieved_at: "2026-04-26T22:14:32Z"
+    source_uuid: "5b4ee3ea-eee3-4c8e-8323-85ae32658754"
   mitre:
-    source_dataset_url: https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack.json
-    source_record_id: G0007
-    source_retrieved_at: '2026-04-26T07:05:44Z'
+    source_dataset_url: "https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack.json"
+    source_record_id: "G0007"
+    source_retrieved_at: "2026-04-26T07:05:44Z"
+  russian_apt_tool_matrix:
+    references:
+      - title: "media.defense.gov"
+        url: "https://media.defense.gov/2021/Jul/01/2002753896/-1/-1/1/CSA_GRU_GLOBAL_BRUTE_FORCE_CAMPAIGN_UOO158036-21.PDF"
+        date: "1 July 2021"
+        source_file: "GroupProfiles/FANCYBEAR.md"
+      - title: "www.trendmicro.com"
+        url: "https://www.trendmicro.com/en_us/research/24/e/router-roulette.html"
+        date: "1 May 2024"
+        source_file: "Other/ThreatIntelligence.md"
+      - title: "www.microsoft.com"
+        url: "https://www.microsoft.com/en-us/security/blog/2020/09/10/strontium-detecting-new-patters-credential-harvesting/"
+        date: "10 September 2020"
+        source_file: "GroupProfiles/FANCYBEAR.md"
+      - title: "web.archive.org"
+        url: "https://web.archive.org/web/20170811181009/https://www.fireeye.com/blog/threat-research/2017/08/apt28-targets-hospitality-sector.html"
+        date: "11 August 2017"
+        source_file: "GroupProfiles/FANCYBEAR.md"
+      - title: "cloud.google.com"
+        url: "https://cloud.google.com/blog/topics/threat-intelligence/probable-apt28-useo/"
+        date: "18 April 2015"
+        source_file: "GroupProfiles/FANCYBEAR.md"
+      - title: "www.cisa.gov"
+        url: "https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-108"
+        date: "18 April 2018"
+        source_file: "GroupProfiles/FANCYBEAR.md"
+      - title: "cert.gov.ua"
+        url: "https://cert.gov.ua/article/6281123"
+        date: "25 October 2024"
+        source_file: "GroupProfiles/FANCYBEAR.md"
+      - title: "cert.gov.ua"
+        url: "https://cert.gov.ua/article/6276894"
+        date: "28 December 2023"
+        source_file: "GroupProfiles/FANCYBEAR.md"
+      - title: "securelist.com"
+        url: "https://securelist.com/sofacy-apt-hits-high-profile-targets-with-updated-toolset/72924/"
+        date: "4 December 2015"
+        source_file: "GroupProfiles/FANCYBEAR.md"
+      - title: "unit42.paloaltonetworks.com"
+        url: "https://unit42.paloaltonetworks.com/unit42-sofacy-groups-parallel-attacks/"
+        date: "6 June 2018"
+        source_file: "GroupProfiles/FANCYBEAR.md"
+      - title: "securityintelligence.com"
+        url: "https://securityintelligence.com/x-force/itg05-ops-leverage-israel-hamas-conflict-lures-to-deliver-headlace-malware/"
+        date: "8 December 2023"
+        source_file: "GroupProfiles/FANCYBEAR.md"
+    source_attribution: "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence."
+    source_dataset_url: "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1"
+    source_files: ["GroupProfiles/FANCYBEAR.md","Other/ThreatIntelligence.md","Tools/CredentialTheft.md","Tools/LOLBAS.md","Tools/Networking.md","Tools/Offsec.md"]
+    source_label: "FANCY BEAR"
+    source_repository: "https://github.com/BushidoUK/Russian-APT-Tool-Matrix"
+    source_retrieved_at: "2026-04-28T02:07:35Z"
+    tools_by_category:
+      Credential Theft: ["Mimikatz"]
+      LOLBAS: ["MiniDump","Windows Event Utility (wevtutil)"]
+      Networking: ["OpenSSH","ReGeorg","SSHDoor"]
+      OffSec: ["Empyre","Impacket","Koadic","Metasploit","Nishang","PowerShell Empire","Responder"]

--- a/_data/actors/apt29.yml
+++ b/_data/actors/apt29.yml
@@ -1,89 +1,23 @@
----
-name: APT29
-aliases:
-- APT29
-- Blue Kitsune
-- Cozy Bear
-- CozyDuke
-- Dark Halo
-- IRON HEMLOCK
-- IRON RITUAL
-- Midnight Blizzard
-- NOBELIUM
-- NobleBaron
-- SolarStorm
-- The Dukes
-- UNC2452
-- UNC3524
-- YTTRIUM
-- Group 100
-- COZY BEAR
-- Minidionis
-- SeaDuke
-- Grizzly Steppe
-- G0016
-- ATK7
-- Cloaked Ursa
-- TA421
-- ITG11
-- BlueBravo
-- Nobelium
-- UAC-0029
-description: |-
-  APT29 is threat group that has been attributed to Russia's Foreign Intelligence Service (SVR).(Citation: White House Imposing Costs RU Gov April 2021)(Citation: UK Gov Malign RIS Activity April 2021) They have operated since at least 2008, often targeting government networks in Europe and NATO member countries, research institutes, and think tanks. APT29 reportedly compromised the Democratic National Committee starting in the summer of 2015.(Citation: F-Secure The Dukes)(Citation: GRIZZLY STEPPE JAR)(Citation: Crowdstrike DNC June 2016)(Citation: UK Gov UK Exposes Russia SolarWinds April 2021)
-
-  In April 2021, the US and UK governments attributed the SolarWinds Compromise to the SVR; public statements included citations to APT29, Cozy Bear, and The Dukes.(Citation: NSA Joint Advisory SVR SolarWinds April 2021)(Citation: UK NSCS Russia SolarWinds April 2021) Industry reporting also referred to the actors involved in this campaign as UNC2452, NOBELIUM, StellarParticle, Dark Halo, and SolarStorm.(Citation: FireEye SUNBURST Backdoor December 2020)(Citation: MSTIC NOBELIUM Mar 2021)(Citation: CrowdStrike SUNSPOT Implant January 2021)(Citation: Volexity SolarWinds)(Citation: Cybersecurity Advisory SVR TTP May 2021)(Citation: Unit 42 SolarStorm December 2020)
+name: "APT29"
+aliases: ["APT29","Blue Kitsune","Cozy Bear","CozyDuke","Dark Halo","IRON HEMLOCK","IRON RITUAL","Midnight Blizzard","NOBELIUM","NobleBaron","SolarStorm","The Dukes","UNC2452","UNC3524","YTTRIUM","Group 100","COZY BEAR","Minidionis","SeaDuke","Grizzly Steppe","G0016","ATK7","Cloaked Ursa","TA421","ITG11","BlueBravo","Nobelium","UAC-0029"]
+description: "APT29 is threat group that has been attributed to Russia's Foreign Intelligence Service (SVR).(Citation: White House Imposing Costs RU Gov April 2021)(Citation: UK Gov Malign RIS Activity April 2021) They have operated since at least 2008, often targeting government networks in Europe and NATO member countries, research institutes, and think tanks. APT29 reportedly compromised the Democratic National Committee starting in the summer of 2015.(Citation: F-Secure The Dukes)(Citation: GRIZZLY STEPPE JAR)(Citation: Crowdstrike DNC June 2016)(Citation: UK Gov UK Exposes Russia SolarWinds April 2021)\n\nIn April 2021, the US and UK governments attributed the SolarWinds Compromise to the SVR; public statements included citations to APT29, Cozy Bear, and The Dukes.(Citation: NSA Joint Advisory SVR SolarWinds April 2021)(Citation: UK NSCS Russia SolarWinds April 2021) Industry reporting also referred to the actors involved in this campaign as UNC2452, NOBELIUM, StellarParticle, Dark Halo, and SolarStorm.(Citation: FireEye SUNBURST Backdoor December 2020)(Citation: MSTIC NOBELIUM Mar 2021)(Citation: CrowdStrike SUNSPOT Implant January 2021)(Citation: Volexity SolarWinds)(Citation: Cybersecurity Advisory SVR TTP May 2021)(Citation: Unit 42 SolarStorm December 2020)"
 url: "/apt29"
-country: Russia
-sector_focus:
-- Government
-- Healthcare
-- Energy
-targeted_victims:
-- United States
-- China
-- New Zealand
-- Ukraine
-- Romania
-- Georgia
-- Japan
-- South Korea
-- Belgium
-- Kazakhstan
-- Brazil
-- Mexico
-- Turkey
-- Portugal
-- India
-- Germany
-incident_type: Espionage
-first_seen: '2008'
-last_activity: '2024'
-last_updated: "2026-04-27"
-risk_level: High
-external_id: G0016
-external_url: https://attack.mitre.org/groups/G0016
-mitre_id: G0016
-mitre_url: https://attack.mitre.org/groups/G0016
-source_attribution: "© The MITRE Corporation. This work is reproduced and distributed
-  with the permission of The MITRE Corporation."
-malware:
-- CosmicDuke
-- PinchDuke
-- CloudDuke
-- HAMMERTOSS
-- GeminiDuke
-- MiniDuke
-- SeaDuke
-- RTM
-- OnionDuke
-- CyberGate
+country: "Russia"
+sector_focus: ["Government","Healthcare","Energy"]
+targeted_victims: ["United States","China","New Zealand","Ukraine","Romania","Georgia","Japan","South Korea","Belgium","Kazakhstan","Brazil","Mexico","Turkey","Portugal","India","Germany"]
+incident_type: "Espionage"
+first_seen: "2008"
+last_activity: "2024"
+last_updated: "2026-04-28"
+risk_level: "High"
+external_id: "G0016"
+external_url: "https://attack.mitre.org/groups/G0016"
+mitre_id: "G0016"
+mitre_url: "https://attack.mitre.org/groups/G0016"
+source_attribution: "© The MITRE Corporation. This work is reproduced and distributed with the permission of The MITRE Corporation."
+malware: ["CosmicDuke","PinchDuke","CloudDuke","HAMMERTOSS","GeminiDuke","MiniDuke","SeaDuke","RTM","OnionDuke","CyberGate"]
 provenance:
   bushido_breach_reports:
-    source_repository: "https://github.com/BushidoUK/Breach-Report-Collection"
-    source_dataset_url: "https://raw.githubusercontent.com/BushidoUK/Breach-Report-Collection/main/README.md"
-    source_attribution: "References were identified via the BushidoToken Breach Report Collection (https://github.com/BushidoUK/Breach-Report-Collection), which is used here as a report index. Copyright in linked reports remains with the original publishers."
-    source_retrieved_at: "2026-04-28T01:40:03Z"
     reports:
       - organization: "Microsoft"
         breach_date: "January 2024"
@@ -105,7 +39,71 @@ provenance:
         adversary_label: "CozyBear (RU APT)"
         links: ["https://orangematter.solarwinds.com/2021/01/11/new-findings-from-our-investigation-of-sunburst/"]
         archived_links: ["https://web.archive.org/web/20230209021934/https://orangematter.solarwinds.com/2021/01/11/new-findings-from-our-investigation-of-sunburst/"]
+    source_attribution: "References were identified via the BushidoToken Breach Report Collection (https://github.com/BushidoUK/Breach-Report-Collection), which is used here as a report index. Copyright in linked reports remains with the original publishers."
+    source_dataset_url: "https://raw.githubusercontent.com/BushidoUK/Breach-Report-Collection/main/README.md"
+    source_repository: "https://github.com/BushidoUK/Breach-Report-Collection"
+    source_retrieved_at: "2026-04-28T01:40:03Z"
   mitre:
-    source_dataset_url: https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack.json
-    source_record_id: G0016
-    source_retrieved_at: '2026-04-26T05:24:31Z'
+    source_dataset_url: "https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack.json"
+    source_record_id: "G0016"
+    source_retrieved_at: "2026-04-26T05:24:31Z"
+  russian_apt_tool_matrix:
+    references:
+      - title: "www.cisa.gov"
+        url: "https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-347a"
+        date: "13 December 2023"
+        source_file: "GroupProfiles/COZYBEAR.md"
+      - title: "www.gov.uk"
+        url: "https://www.gov.uk/government/news/russia-uk-and-us-expose-global-campaigns-of-malign-activity-by-russian-intelligence-services"
+        date: "15 April 2021"
+        source_file: "GroupProfiles/COZYBEAR.md"
+      - title: "research.checkpoint.com"
+        url: "https://research.checkpoint.com/2025/apt29-phishing-campaign/"
+        date: "15 April 2025"
+        source_file: "Other/ThreatIntelligence.md"
+      - title: "www.microsoft.com"
+        url: "https://www.microsoft.com/en-us/security/blog/2020/12/18/analyzing-solorigate-the-compromised-dll-file-that-started-a-sophisticated-cyberattack-and-how-microsoft-defender-helps-protect/"
+        date: "18 December 2020"
+        source_file: "GroupProfiles/COZYBEAR.md"
+      - title: "www.cert.ssi.gouv.fr"
+        url: "https://www.cert.ssi.gouv.fr/cti/CERTFR-2024-CTI-006/"
+        date: "19 June 2024"
+        source_file: "Other/ThreatIntelligence.md"
+      - title: "cloud.google.com"
+        url: "https://cloud.google.com/blog/topics/threat-intelligence/unc3524-eye-spy-email/"
+        date: "2 May 2022"
+        source_file: "GroupProfiles/COZYBEAR.md"
+      - title: "www.microsoft.com"
+        url: "https://www.microsoft.com/en-us/security/blog/2021/10/25/nobelium-targeting-delegated-administrative-privileges-to-facilitate-broader-attacks/"
+        date: "25 October 2021"
+        source_file: "GroupProfiles/COZYBEAR.md"
+      - title: "www.zscaler.com"
+        url: "https://www.zscaler.com/blogs/security-research/european-diplomats-targeted-apt29-cozy-bear-wineloader"
+        date: "27 February 2024"
+        source_file: "Other/ThreatIntelligence.md"
+      - title: "www.crowdstrike.com"
+        url: "https://www.crowdstrike.com/blog/observations-from-the-stellarparticle-campaign/"
+        date: "27 January 2022"
+        source_file: "GroupProfiles/COZYBEAR.md"
+      - title: "go.recordedfuture.com"
+        url: "https://go.recordedfuture.com/hubfs/reports/cta-2023-0127.pdf"
+        date: "27 January 2023"
+        source_file: "GroupProfiles/COZYBEAR.md"
+      - title: "www.microsoft.com"
+        url: "https://www.microsoft.com/en-us/security/blog/2021/05/27/new-sophisticated-email-based-attack-from-nobelium/"
+        date: "27 May 2021"
+        source_file: "GroupProfiles/COZYBEAR.md"
+    source_attribution: "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence."
+    source_dataset_url: "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1"
+    source_files: ["GroupProfiles/COZYBEAR.md","Other/ThreatIntelligence.md","Tools/CredentialTheft.md","Tools/DefenseEvasion.md","Tools/Discovery.md","Tools/Exfiltration.md","Tools/LOLBAS.md","Tools/Networking.md","Tools/Offsec.md"]
+    source_label: "COZY BEAR"
+    source_repository: "https://github.com/BushidoUK/Russian-APT-Tool-Matrix"
+    source_retrieved_at: "2026-04-28T02:07:35Z"
+    tools_by_category:
+      Credential Theft: ["CookieEditor","Mimikatz","SharpChormium","SharpChromium"]
+      Defense Evasion: ["EDRSandBlast","VMware Tools (DLL side-loading)"]
+      Discovery: ["AADInternals","AdFind","Bloodhound","DSInternals","RoadTools"]
+      Exfiltration: ["Dropbox","Firebase","Google Drive","Notion","OneDrive","Trello"]
+      LOLBAS: ["PowerPoint.exe (DLL side-loading)","PsExec","WMIC","sqlwriter.exe (DLL side-loading)"]
+      Networking: ["Dropbear","ReGeorg","Rosockstun","Rsockstun"]
+      OffSec: ["Brute Ratel C4","Cobalt Strike","Impacket","PowerSploit","Rubeus","Sliver","WinPEAS"]

--- a/_data/actors/cold-river.yml
+++ b/_data/actors/cold-river.yml
@@ -1,16 +1,29 @@
----
-name: Cold River
-aliases:
-- Nahr Elbard
-- Nahr el bared
-- Cold River
-description: In short, “Cold River” is a sophisticated threat (actor) that utilizes
-  DNS subdomain hijacking, certificate spoofing, and covert tunneled command and control
-  traffic in combination with complex and convincing lure documents and custom implants.
+name: "Cold River"
+aliases: ["Nahr Elbard","Nahr el bared","Cold River"]
+description: "In short, “Cold River” is a sophisticated threat (actor) that utilizes DNS subdomain hijacking, certificate spoofing, and covert tunneled command and control traffic in combination with complex and convincing lure documents and custom implants."
 url: "/cold-river"
+last_updated: "2026-04-28"
+source_attribution: "Data sourced from MISP Galaxy threat-actor cluster (CC0 licensed)"
 provenance:
   misp_galaxy:
-    source_dataset_url: https://raw.githubusercontent.com/MISP/misp-galaxy/main/clusters/threat-actor.json
-    source_record_id: 7d99d2f7-adf0-44e4-9044-d18ff6842a16
-    source_retrieved_at: '2026-04-26T05:47:15Z'
-source_attribution: Data sourced from MISP Galaxy threat-actor cluster (CC0 licensed)
+    source_dataset_url: "https://raw.githubusercontent.com/MISP/misp-galaxy/main/clusters/threat-actor.json"
+    source_record_id: "7d99d2f7-adf0-44e4-9044-d18ff6842a16"
+    source_retrieved_at: "2026-04-26T05:47:15Z"
+  russian_apt_tool_matrix:
+    references:
+      - title: "citizenlab.ca"
+        url: "https://citizenlab.ca/2024/08/sophisticated-phishing-targets-russias-perceived-enemies-around-the-globe/"
+        date: "14 August 2024"
+        source_file: "GroupProfiles/COLDRIVER.md"
+      - title: "www.ncsc.gov.uk"
+        url: "https://www.ncsc.gov.uk/news/uk-and-allies-expose-cyber-campaign-attempted-political-interference"
+        date: "7 December 2023"
+        source_file: "GroupProfiles/COLDRIVER.md"
+    source_attribution: "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence."
+    source_dataset_url: "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1"
+    source_files: ["GroupProfiles/COLDRIVER.md","Other/ThreatIntelligence.md","Tools/Offsec.md"]
+    source_label: "COLDRIVER / Star Blizzard"
+    source_repository: "https://github.com/BushidoUK/Russian-APT-Tool-Matrix"
+    source_retrieved_at: "2026-04-28T02:07:35Z"
+    tools_by_category:
+      OffSec: ["EvilGinx"]

--- a/_data/actors/curly-comrades.yml
+++ b/_data/actors/curly-comrades.yml
@@ -1,21 +1,32 @@
----
-name: Curly COMrades
-aliases:
-- Curly COMrades
-description: Curly COMrades is a threat actor identified by Amazon Threat Intelligence
-  and Bitdefender, believed to operate in support of Russian interests. They employ
-  techniques such as Hyper-V abuse for EDR evasion and utilize proxy tools like Resocks,
-  SSH, and Stunnel to gain access to internal networks. Their activities include repeated
-  attempts to extract the NTDS database from domain controllers and establishing covert
-  access through virtualization features on compromised Windows 10 machines.
+name: "Curly COMrades"
+aliases: ["Curly COMrades"]
+description: "Curly COMrades is a threat actor identified by Amazon Threat Intelligence and Bitdefender, believed to operate in support of Russian interests. They employ techniques such as Hyper-V abuse for EDR evasion and utilize proxy tools like Resocks, SSH, and Stunnel to gain access to internal networks. Their activities include repeated attempts to extract the NTDS database from domain controllers and establishing covert access through virtualization features on compromised Windows 10 machines."
 url: "/curly-comrades"
-country: Russia
-malware:
-- ComRAT
-- Windows Remote Desktop
+country: "Russia"
+last_updated: "2026-04-28"
+source_attribution: "Data sourced from MISP Galaxy threat-actor cluster (CC0 licensed)"
+malware: ["ComRAT","Windows Remote Desktop"]
 provenance:
   misp_galaxy:
-    source_dataset_url: https://raw.githubusercontent.com/MISP/misp-galaxy/main/clusters/threat-actor.json
-    source_record_id: 7bf6ae38-fcd3-4a99-99ba-292990a27f0a
-    source_retrieved_at: '2026-04-26T05:47:15Z'
-source_attribution: Data sourced from MISP Galaxy threat-actor cluster (CC0 licensed)
+    source_dataset_url: "https://raw.githubusercontent.com/MISP/misp-galaxy/main/clusters/threat-actor.json"
+    source_record_id: "7bf6ae38-fcd3-4a99-99ba-292990a27f0a"
+    source_retrieved_at: "2026-04-26T05:47:15Z"
+  russian_apt_tool_matrix:
+    references:
+      - title: "businessinsights.bitdefender.com"
+        url: "https://businessinsights.bitdefender.com/curly-comrades-new-threat-actor-targeting-geopolitical-hotbeds"
+        date: "12 August 2025"
+        source_file: "Other/ThreatIntelligence.md"
+    source_attribution: "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence."
+    source_dataset_url: "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1"
+    source_files: ["Other/ThreatIntelligence.md","Tools/CredentialTheft.md","Tools/DefenseEvasion.md","Tools/LOLBAS.md","Tools/Networking.md","Tools/Offsec.md","Tools/RMM-Tools.md"]
+    source_label: "Curly COMrades"
+    source_repository: "https://github.com/BushidoUK/Russian-APT-Tool-Matrix"
+    source_retrieved_at: "2026-04-28T02:07:35Z"
+    tools_by_category:
+      Credential Theft: ["Mimikatz","ProcDump","TrickDump"]
+      Defense Evasion: ["Garble"]
+      LOLBAS: ["DCSync","curl"]
+      Networking: ["Resocks","SOCKS5","stunnel"]
+      OffSec: ["Impacket"]
+      RMM Tools: ["RemoteUtilities"]

--- a/_data/actors/sandworm.yml
+++ b/_data/actors/sandworm.yml
@@ -1,75 +1,55 @@
----
-name: Sandworm
-aliases:
-- Quedagh
-- VOODOO BEAR
-- TEMP.Noble
-- IRON VIKING
-- G0034
-- ELECTRUM
-- TeleBots
-- IRIDIUM
-- Blue Echidna
-- FROZENBARENTS
-- UAC-0113
-- Seashell Blizzard
-- UAC-0082
-- APT44
-- Sandworm
-description: This threat actor targets industrial control systems, using a tool called
-  Black Energy, associated with electricity and power generation for espionage, denial
-  of service, and data destruction purposes. Some believe that the threat actor is
-  linked to the 2015 compromise of the Ukrainian electrical grid and a distributed
-  denial of service prior to the Russian invasion of Georgia. Believed to be responsible
-  for the 2008 DDoS attacks in Georgia and the 2015 Ukraine power grid outage
+name: "Sandworm"
+aliases: ["Quedagh","VOODOO BEAR","TEMP.Noble","IRON VIKING","G0034","ELECTRUM","TeleBots","IRIDIUM","Blue Echidna","FROZENBARENTS","UAC-0113","Seashell Blizzard","UAC-0082","APT44","Sandworm"]
+description: "This threat actor targets industrial control systems, using a tool called Black Energy, associated with electricity and power generation for espionage, denial of service, and data destruction purposes. Some believe that the threat actor is linked to the 2015 compromise of the Ukrainian electrical grid and a distributed denial of service prior to the Russian invasion of Georgia. Believed to be responsible for the 2008 DDoS attacks in Georgia and the 2015 Ukraine power grid outage"
 url: "/sandworm"
-country: Russia
-sector_focus:
-- Electric
-- Energy
-- Industrial
-- Private sector
-- Government
-targeted_victims:
-- Russia
-- Lithuania
-- Kyrgyzstan
-- Israel
-- Ukraine
-- Belarus
-- Kazakhstan
-- Georgia
-- Poland
-- Azerbaijan
-- Iran
-incident_type: Espionage
-risk_level: High
-last_updated: "2026-04-27"
-malware:
-- BlackEnergy
-- PowerDuke
-- POWERSTATS
-- Power Loader
-- POWERSOURCE
-- BLACKCOFFEE
-- Blackshades
-- BlackNix
-- BlackHole
-- PowerRAT
+country: "Russia"
+sector_focus: ["Electric","Energy","Industrial","Private sector","Government"]
+targeted_victims: ["Russia","Lithuania","Kyrgyzstan","Israel","Ukraine","Belarus","Kazakhstan","Georgia","Poland","Azerbaijan","Iran"]
+incident_type: "Espionage"
+last_updated: "2026-04-28"
+risk_level: "High"
+source_attribution: "Data sourced from MISP Galaxy threat-actor cluster (CC0 licensed)"
+malware: ["BlackEnergy","PowerDuke","POWERSTATS","Power Loader","POWERSOURCE","BLACKCOFFEE","Blackshades","BlackNix","BlackHole","PowerRAT"]
 provenance:
   bushido_breach_reports:
-    source_repository: "https://github.com/BushidoUK/Breach-Report-Collection"
-    source_dataset_url: "https://raw.githubusercontent.com/BushidoUK/Breach-Report-Collection/main/README.md"
-    source_attribution: "References were identified via the BushidoToken Breach Report Collection (https://github.com/BushidoUK/Breach-Report-Collection), which is used here as a report index. Copyright in linked reports remains with the original publishers."
-    source_retrieved_at: "2026-04-28T01:40:03Z"
     reports:
       - organization: "Viasat KA-SAT"
         breach_date: "February 2022"
         adversary_label: "Sandworm (RU APT)"
         links: ["https://news.viasat.com/blog/corporate/ka-sat-network-cyber-attack-overview"]
         archived_links: ["https://web.archive.org/web/20230407225107/https://news.viasat.com/blog/corporate/ka-sat-network-cyber-attack-overview"]
+    source_attribution: "References were identified via the BushidoToken Breach Report Collection (https://github.com/BushidoUK/Breach-Report-Collection), which is used here as a report index. Copyright in linked reports remains with the original publishers."
+    source_dataset_url: "https://raw.githubusercontent.com/BushidoUK/Breach-Report-Collection/main/README.md"
+    source_repository: "https://github.com/BushidoUK/Breach-Report-Collection"
+    source_retrieved_at: "2026-04-28T01:40:03Z"
   misp_galaxy:
-    source_dataset_url: https://raw.githubusercontent.com/MISP/misp-galaxy/main/clusters/threat-actor.json
-    source_record_id: f512de42-f76b-40d2-9923-59e7dbdfec35
-    source_retrieved_at: '2026-04-26T05:47:15Z'
-source_attribution: Data sourced from MISP Galaxy threat-actor cluster (CC0 licensed)
+    source_dataset_url: "https://raw.githubusercontent.com/MISP/misp-galaxy/main/clusters/threat-actor.json"
+    source_record_id: "f512de42-f76b-40d2-9923-59e7dbdfec35"
+    source_retrieved_at: "2026-04-26T05:47:15Z"
+  russian_apt_tool_matrix:
+    references:
+      - title: "www.microsoft.com"
+        url: "https://www.microsoft.com/en-us/security/blog/2025/02/12/the-badpilot-campaign-seashell-blizzard-subgroup-conducts-multiyear-global-access-operation/"
+        date: "12 February 2025"
+        source_file: "GroupProfiles/Sandworm.md"
+      - title: "services.google.com"
+        url: "https://services.google.com/fh/files/misc/apt44-unearthing-sandworm.pdf"
+        date: "17 April 2024"
+        source_file: "GroupProfiles/Sandworm.md"
+      - title: "cert.gov.ua"
+        url: "https://cert.gov.ua/article/6278706"
+        date: "19 April 2024"
+        source_file: "GroupProfiles/Sandworm.md"
+    source_attribution: "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence."
+    source_dataset_url: "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1"
+    source_files: ["GroupProfiles/Sandworm.md","Other/ThreatIntelligence.md","Tools/DefenseEvasion.md","Tools/Exfiltration.md","Tools/LOLBAS.md","Tools/Networking.md","Tools/Offsec.md","Tools/RMM-Tools.md"]
+    source_label: "Sandworm"
+    source_repository: "https://github.com/BushidoUK/Russian-APT-Tool-Matrix"
+    source_retrieved_at: "2026-04-28T02:07:35Z"
+    tools_by_category:
+      Defense Evasion: ["SDelete","libprocesshider"]
+      Exfiltration: ["Rclone"]
+      LOLBAS: ["BITSAdmin","BITSadmin","certutil","curl"]
+      Networking: ["Chisel","OpenSSH","Pivotnacci","ReGeorg","Tor"]
+      OffSec: ["Cobalt Strike","Empyre","Impacket","JuicyPotatoNG","Metasploit","Meterpreter","PAS Web Shell","PoshC2","PowerShell Empire","RottenPotatoNG","WSO Web Shell","Weevely Web Shell"]
+      RMM Tools: ["Atera","RemCom","Splashtop"]

--- a/_data/actors/uta0352.yml
+++ b/_data/actors/uta0352.yml
@@ -1,23 +1,27 @@
----
-name: UTA0352
-aliases:
-- UTA0352
-description: UTA0352 is a Russian threat actor attributed to phishing campaigns that
-  exploit Microsoft OAuth 2.0 authentication workflows, often impersonating government
-  officials to lure targets into providing sensitive information. The actor has been
-  observed using malicious URLs disguised as legitimate services, such as a Romanian
-  government authentication system. UTA0352 has also targeted Microsoft Teams and
-  employed social engineering tactics via messaging platforms like Signal and WhatsApp.
-  Volexity assesses with medium confidence that UTA0352 is involved in operations
-  themed around Ukraine, targeting individuals and organizations historically associated
-  with Russian threat activities.
+name: "UTA0352"
+aliases: ["UTA0352"]
+description: "UTA0352 is a Russian threat actor attributed to phishing campaigns that exploit Microsoft OAuth 2.0 authentication workflows, often impersonating government officials to lure targets into providing sensitive information. The actor has been observed using malicious URLs disguised as legitimate services, such as a Romanian government authentication system. UTA0352 has also targeted Microsoft Teams and employed social engineering tactics via messaging platforms like Signal and WhatsApp. Volexity assesses with medium confidence that UTA0352 is involved in operations themed around Ukraine, targeting individuals and organizations historically associated with Russian threat activities."
 url: "/uta0352"
-country: Russia
-malware:
-- Xploit
+country: "Russia"
+last_updated: "2026-04-28"
+source_attribution: "Data sourced from MISP Galaxy threat-actor cluster (CC0 licensed)"
+malware: ["Xploit"]
 provenance:
   misp_galaxy:
-    source_dataset_url: https://raw.githubusercontent.com/MISP/misp-galaxy/main/clusters/threat-actor.json
-    source_record_id: 63305373-15a8-4f84-ab09-27ffeaa99ae2
-    source_retrieved_at: '2026-04-26T05:47:15Z'
-source_attribution: Data sourced from MISP Galaxy threat-actor cluster (CC0 licensed)
+    source_dataset_url: "https://raw.githubusercontent.com/MISP/misp-galaxy/main/clusters/threat-actor.json"
+    source_record_id: "63305373-15a8-4f84-ab09-27ffeaa99ae2"
+    source_retrieved_at: "2026-04-26T05:47:15Z"
+  russian_apt_tool_matrix:
+    references:
+      - title: "www.volexity.com"
+        url: "https://www.volexity.com/blog/2025/04/22/phishing-for-codes-russian-threat-actors-target-microsoft-365-oauth-workflows/"
+        date: "22 April 2025"
+        source_file: "Other/ThreatIntelligence.md"
+    source_attribution: "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence."
+    source_dataset_url: "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1"
+    source_files: ["Other/ThreatIntelligence.md","Tools/Networking.md"]
+    source_label: "UTA0352 / UTA0352, UTA0355"
+    source_repository: "https://github.com/BushidoUK/Russian-APT-Tool-Matrix"
+    source_retrieved_at: "2026-04-28T02:07:35Z"
+    tools_by_category:
+      Networking: ["insiders[.]vscode[.]dev","vscode-redirect[.]azurewebsites.net"]

--- a/_data/actors/uta0355.yml
+++ b/_data/actors/uta0355.yml
@@ -1,20 +1,24 @@
----
-name: UTA0355
-aliases:
-- UTA0355
-description: UTA0355 is a Russian threat actor that conducts phishing campaigns targeting
-  individuals and organizations associated with Ukraine. The actor initiates contact
-  via email, inviting targets to a video conference, and follows up through Signal
-  or WhatsApp to enhance legitimacy. After establishing communication, UTA0355 prompts
-  victims to log in via a malicious M365 URL, subsequently requesting approval for
-  a 2FA authentication to access email data. Volexity assesses with high confidence
-  that UTA0355 successfully registered devices and downloaded email data from compromised
-  accounts.
+name: "UTA0355"
+aliases: ["UTA0355"]
+description: "UTA0355 is a Russian threat actor that conducts phishing campaigns targeting individuals and organizations associated with Ukraine. The actor initiates contact via email, inviting targets to a video conference, and follows up through Signal or WhatsApp to enhance legitimacy. After establishing communication, UTA0355 prompts victims to log in via a malicious M365 URL, subsequently requesting approval for a 2FA authentication to access email data. Volexity assesses with high confidence that UTA0355 successfully registered devices and downloaded email data from compromised accounts."
 url: "/uta0355"
-country: Russia
+country: "Russia"
+last_updated: "2026-04-28"
+source_attribution: "Data sourced from MISP Galaxy threat-actor cluster (CC0 licensed)"
 provenance:
   misp_galaxy:
-    source_dataset_url: https://raw.githubusercontent.com/MISP/misp-galaxy/main/clusters/threat-actor.json
-    source_record_id: b4bbbd06-a204-4363-90d2-f38cc0def521
-    source_retrieved_at: '2026-04-26T05:47:15Z'
-source_attribution: Data sourced from MISP Galaxy threat-actor cluster (CC0 licensed)
+    source_dataset_url: "https://raw.githubusercontent.com/MISP/misp-galaxy/main/clusters/threat-actor.json"
+    source_record_id: "b4bbbd06-a204-4363-90d2-f38cc0def521"
+    source_retrieved_at: "2026-04-26T05:47:15Z"
+  russian_apt_tool_matrix:
+    references:
+      - title: "www.volexity.com"
+        url: "https://www.volexity.com/blog/2025/04/22/phishing-for-codes-russian-threat-actors-target-microsoft-365-oauth-workflows/"
+        date: "22 April 2025"
+        source_file: "Other/ThreatIntelligence.md"
+    source_attribution: "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence."
+    source_dataset_url: "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1"
+    source_files: ["Other/ThreatIntelligence.md"]
+    source_label: "UTA0352, UTA0355"
+    source_repository: "https://github.com/BushidoUK/Russian-APT-Tool-Matrix"
+    source_retrieved_at: "2026-04-28T02:07:35Z"

--- a/_data/actors/void-blizzard.yml
+++ b/_data/actors/void-blizzard.yml
@@ -1,24 +1,28 @@
----
-name: Void Blizzard
-aliases:
-- LAUNDRY BEAR
-- UAC-0190
-- Void Blizzard
-description: Void Blizzard’s cyberespionage operations tend to be highly targeted
-  at specific organizations of interest to the Russian government, including in government,
-  defense, transportation, media, non-governmental organizations (NGOs), and healthcare
-  sectors primarily in Europe and North America. The threat actor uses stolen credentials—which
-  are likely procured from commodity infostealer ecosystems—and collects a high volume
-  of email and files from compromised organizations.
+name: "Void Blizzard"
+aliases: ["LAUNDRY BEAR","UAC-0190","Void Blizzard"]
+description: "Void Blizzard’s cyberespionage operations tend to be highly targeted at specific organizations of interest to the Russian government, including in government, defense, transportation, media, non-governmental organizations (NGOs), and healthcare sectors primarily in Europe and North America. The threat actor uses stolen credentials—which are likely procured from commodity infostealer ecosystems—and collects a high volume of email and files from compromised organizations."
 url: "/void-blizzard"
-country: Russia
-malware:
-- CyberGate
-- Cyber Eye RAT
-- Blizzard
+country: "Russia"
+last_updated: "2026-04-28"
+source_attribution: "Data sourced from MISP Galaxy threat-actor cluster (CC0 licensed)"
+malware: ["CyberGate","Cyber Eye RAT","Blizzard"]
 provenance:
   misp_galaxy:
-    source_dataset_url: https://raw.githubusercontent.com/MISP/misp-galaxy/main/clusters/threat-actor.json
-    source_record_id: b495419f-e327-4bbe-aba5-0c281dc2605b
-    source_retrieved_at: '2026-04-26T05:47:15Z'
-source_attribution: Data sourced from MISP Galaxy threat-actor cluster (CC0 licensed)
+    source_dataset_url: "https://raw.githubusercontent.com/MISP/misp-galaxy/main/clusters/threat-actor.json"
+    source_record_id: "b495419f-e327-4bbe-aba5-0c281dc2605b"
+    source_retrieved_at: "2026-04-26T05:47:15Z"
+  russian_apt_tool_matrix:
+    references:
+      - title: "www.microsoft.com"
+        url: "https://www.microsoft.com/en-us/security/blog/2025/05/27/new-russia-affiliated-actor-void-blizzard-targets-critical-sectors-for-espionage/"
+        date: "27 May 2025"
+        source_file: "Other/ThreatIntelligence.md"
+    source_attribution: "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence."
+    source_dataset_url: "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1"
+    source_files: ["Other/ThreatIntelligence.md","Tools/Discovery.md","Tools/Offsec.md"]
+    source_label: "Void Blizzard / Void Blizzard/LAUNDRY BEAR"
+    source_repository: "https://github.com/BushidoUK/Russian-APT-Tool-Matrix"
+    source_retrieved_at: "2026-04-28T02:07:35Z"
+    tools_by_category:
+      Discovery: ["AzureHound"]
+      OffSec: ["EvilGinx"]

--- a/_data/generated/recently_updated.json
+++ b/_data/generated/recently_updated.json
@@ -1,5 +1,24 @@
 [
   {
+    "name": "Void Blizzard",
+    "aliases": [
+      "LAUNDRY BEAR",
+      "UAC-0190",
+      "Void Blizzard"
+    ],
+    "description": "Void Blizzard’s cyberespionage operations tend to be highly targeted at specific organizations of interest to the Russian government, including in government, defense, transportation, media, non-governmental organizations (NGOs), and healthcare sectors primarily in Europe and North America. The threat actor uses stolen credentials—which are likely procured from commodity infostealer ecosystems—and collects a high volume of email and files from compromised organizations.",
+    "url": "/void-blizzard",
+    "permalink": "/void-blizzard/",
+    "country": "Russia",
+    "sector_focus": [
+
+    ],
+    "risk_level": null,
+    "last_updated": "2026-04-28",
+    "last_activity": null,
+    "ioc_count": 0
+  },
+  {
     "name": "Vanilla Tempest",
     "aliases": [
       "DEV-0832",
@@ -14,6 +33,75 @@
 
     ],
     "risk_level": null,
+    "last_updated": "2026-04-28",
+    "last_activity": null,
+    "ioc_count": 0
+  },
+  {
+    "name": "UTA0355",
+    "aliases": [
+      "UTA0355"
+    ],
+    "description": "UTA0355 is a Russian threat actor that conducts phishing campaigns targeting individuals and organizations associated with Ukraine. The actor initiates contact via email, inviting targets to a video conference, and follows up through Signal or WhatsApp to enhance legitimacy. After establishing communication, UTA0355 prompts victims to log in via a malicious M365 URL, subsequently requesting approval for a 2FA authentication to access email data. Volexity assesses with high confidence that UTA0355 successfully registered devices and downloaded email data from compromised accounts.",
+    "url": "/uta0355",
+    "permalink": "/uta0355/",
+    "country": "Russia",
+    "sector_focus": [
+
+    ],
+    "risk_level": null,
+    "last_updated": "2026-04-28",
+    "last_activity": null,
+    "ioc_count": 0
+  },
+  {
+    "name": "UTA0352",
+    "aliases": [
+      "UTA0352"
+    ],
+    "description": "UTA0352 is a Russian threat actor attributed to phishing campaigns that exploit Microsoft OAuth 2.0 authentication workflows, often impersonating government officials to lure targets into providing sensitive information. The actor has been observed using malicious URLs disguised as legitimate services, such as a Romanian government authentication system. UTA0352 has also targeted Microsoft Teams and employed social engineering tactics via messaging platforms like Signal and WhatsApp. Volexity assesses with medium confidence that UTA0352 is involved in operations themed around Ukraine, targeting individuals and organizations historically associated with Russian threat activities.",
+    "url": "/uta0352",
+    "permalink": "/uta0352/",
+    "country": "Russia",
+    "sector_focus": [
+
+    ],
+    "risk_level": null,
+    "last_updated": "2026-04-28",
+    "last_activity": null,
+    "ioc_count": 0
+  },
+  {
+    "name": "Sandworm",
+    "aliases": [
+      "Quedagh",
+      "VOODOO BEAR",
+      "TEMP.Noble",
+      "IRON VIKING",
+      "G0034",
+      "ELECTRUM",
+      "TeleBots",
+      "IRIDIUM",
+      "Blue Echidna",
+      "FROZENBARENTS",
+      "UAC-0113",
+      "Seashell Blizzard",
+      "UAC-0082",
+      "APT44",
+      "Sandworm"
+    ],
+    "description": "This threat actor targets industrial control systems, using a tool called Black Energy, associated with electricity and power generation for espionage, denial of service, and data destruction purposes. Some believe that the threat actor is linked to the 2015 compromise of the Ukrainian electrical grid and a distributed denial of service prior to the Russian invasion of Georgia. Believed to be responsible for the 2008 DDoS attacks in Georgia and the 2015 Ukraine power grid outage",
+    "url": "/sandworm",
+    "permalink": "/sandworm/",
+    "country": "Russia",
+    "sector_focus": [
+      "Electric",
+      "Energy",
+      "Industrial",
+      "Private sector",
+      "Government"
+    ],
+    "risk_level": "High",
     "last_updated": "2026-04-28",
     "last_activity": null,
     "ioc_count": 0
@@ -154,81 +242,6 @@
     "risk_level": null,
     "last_updated": "2026-04-28",
     "last_activity": null,
-    "ioc_count": 0
-  },
-  {
-    "name": "Medusa",
-    "aliases": [
-      "Medusa Ransomware"
-    ],
-    "description": "Medusa is a long-time presence in the ransomware scene that stepped up its activities in late 2024, pushing past its previous limits.",
-    "url": "/medusa",
-    "permalink": "/medusa/",
-    "country": "Unknown",
-    "sector_focus": [
-      "Healthcare",
-      "Education",
-      "Government",
-      "Technology"
-    ],
-    "risk_level": "High",
-    "last_updated": "2026-04-28",
-    "last_activity": "2025",
-    "ioc_count": 0
-  },
-  {
-    "name": "Maze",
-    "aliases": [
-      "ChaCha"
-    ],
-    "description": "Maze is a ransomware operation known for being the first to implement double extortion tactics.",
-    "url": "/maze",
-    "permalink": "/maze/",
-    "country": "Unknown",
-    "sector_focus": [
-      "Healthcare",
-      "Legal",
-      "Technology"
-    ],
-    "risk_level": "High",
-    "last_updated": "2026-04-28",
-    "last_activity": "2020",
-    "ioc_count": 0
-  },
-  {
-    "name": "Lynx",
-    "aliases": [
-      "Lynx"
-    ],
-    "description": "Lynx is an active ransomware-as-a-service operation tracked by RansomLook.",
-    "url": "/lynx",
-    "permalink": "/lynx/",
-    "country": null,
-    "sector_focus": [
-
-    ],
-    "risk_level": null,
-    "last_updated": "2026-04-28",
-    "last_activity": null,
-    "ioc_count": 0
-  },
-  {
-    "name": "LockBit",
-    "aliases": [
-      "ABCD Ransomware"
-    ],
-    "description": "LockBit is a ransomware-as-a-service operation known for its fast encryption and double extortion tactics.",
-    "url": "/lockbit",
-    "permalink": "/lockbit/",
-    "country": "Russia",
-    "sector_focus": [
-      "Critical Infrastructure",
-      "Healthcare",
-      "Education"
-    ],
-    "risk_level": "Critical",
-    "last_updated": "2026-04-28",
-    "last_activity": "2024",
     "ioc_count": 0
   }
 ]

--- a/_data/generated/threat_actors.json
+++ b/_data/generated/threat_actors.json
@@ -3292,7 +3292,7 @@
     ],
     "first_seen": "2014",
     "last_activity": "2019",
-    "last_updated": null,
+    "last_updated": "2026-04-28",
     "risk_level": "High",
     "source_name": "Malpedia (Fraunhofer FKIE)",
     "source_attribution": "© The MITRE Corporation. This work is reproduced and distributed with the permission of The MITRE Corporation.",
@@ -3390,6 +3390,105 @@
         "source_dataset_url": "https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack.json",
         "source_record_id": "G0010",
         "source_retrieved_at": "2026-04-26T05:24:31Z"
+      },
+      "russian_apt_tool_matrix": {
+        "references": [
+          {
+            "title": "web-assets.esetstatic.com",
+            "url": "https://web-assets.esetstatic.com/wls/2020/05/ESET_Turla_ComRAT.pdf",
+            "date": "15 June 2020",
+            "source_file": "GroupProfiles/Turla.md"
+          },
+          {
+            "title": "web-assets.esetstatic.com",
+            "url": "https://web-assets.esetstatic.com/wls/2018/08/Eset-Turla-Outlook-Backdoor.pdf",
+            "date": "17 August 2018",
+            "source_file": "GroupProfiles/Turla.md"
+          },
+          {
+            "title": "www.welivesecurity.com",
+            "url": "https://www.welivesecurity.com/2020/12/02/turla-crutch-keeping-back-door-open/",
+            "date": "2 December 2020",
+            "source_file": "GroupProfiles/Turla.md"
+          },
+          {
+            "title": "symantec-enterprise-blogs.security.com",
+            "url": "https://symantec-enterprise-blogs.security.com/threat-intelligence/waterbug-espionage-governments",
+            "date": "20 June 2019",
+            "source_file": "GroupProfiles/Turla.md"
+          },
+          {
+            "title": "blog.talosintelligence.com",
+            "url": "https://blog.talosintelligence.com/tinyturla-full-kill-chain/",
+            "date": "21 March 2024",
+            "source_file": "GroupProfiles/Turla.md"
+          },
+          {
+            "title": "www.welivesecurity.com",
+            "url": "https://www.welivesecurity.com/2018/05/22/turla-mosquito-shift-towards-generic-tools/",
+            "date": "22 May 2018",
+            "source_file": "GroupProfiles/Turla.md"
+          },
+          {
+            "title": "www.cisa.gov",
+            "url": "https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-129a",
+            "date": "9 May 2023",
+            "source_file": "GroupProfiles/Turla.md"
+          }
+        ],
+        "source_attribution": "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence.",
+        "source_dataset_url": "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1",
+        "source_files": [
+          "GroupProfiles/Turla.md",
+          "Other/ThreatIntelligence.md",
+          "Tools/CredentialTheft.md",
+          "Tools/DefenseEvasion.md",
+          "Tools/Discovery.md",
+          "Tools/Exfiltration.md",
+          "Tools/LOLBAS.md",
+          "Tools/Offsec.md",
+          "Tools/RMM-Tools.md"
+        ],
+        "source_label": "Turla",
+        "source_repository": "https://github.com/BushidoUK/Russian-APT-Tool-Matrix",
+        "source_retrieved_at": "2026-04-28T02:07:35Z",
+        "tools_by_category": {
+          "Credential Theft": [
+            "Mimikatz"
+          ],
+          "Defense Evasion": [
+            "PowerShellRunner",
+            "VirtualBox Driver"
+          ],
+          "Discovery": [
+            "NBTScan",
+            "SScan"
+          ],
+          "Exfiltration": [
+            "4Shared",
+            "Dropbox",
+            "GMX",
+            "Gmail",
+            "OneDrive",
+            "VFEmail"
+          ],
+          "LOLBAS": [
+            "PsExec"
+          ],
+          "Networking": [
+            "Chisel"
+          ],
+          "OffSec": [
+            "Evil-WinRM",
+            "Metapsloit",
+            "Metasploit",
+            "PowerShell Empire",
+            "PowerSploit"
+          ],
+          "RMM Tools": [
+            "IntelliAdmin"
+          ]
+        }
       }
     },
     "page_path": "_threat_actors/apt0010.md",
@@ -5770,7 +5869,7 @@
     ],
     "first_seen": null,
     "last_activity": null,
-    "last_updated": null,
+    "last_updated": "2026-04-28",
     "risk_level": null,
     "source_name": null,
     "source_attribution": "© The MITRE Corporation. This work is reproduced and distributed with the permission of The MITRE Corporation.",
@@ -5782,6 +5881,74 @@
         "source_dataset_url": "https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack.json",
         "source_record_id": "G0035",
         "source_retrieved_at": "2026-04-26T05:24:31Z"
+      },
+      "russian_apt_tool_matrix": {
+        "references": [
+          {
+            "title": "www.cisa.gov",
+            "url": "https://www.cisa.gov/news-events/alerts/2018/03/15/russian-government-cyber-activity-targeting-energy-and-other-critical-infrastructure-sectors",
+            "date": "16 March 2018",
+            "source_file": "GroupProfiles/BERSERKBEAR.md"
+          },
+          {
+            "title": "symantec-enterprise-blogs.security.com",
+            "url": "https://symantec-enterprise-blogs.security.com/threat-intelligence/dragonfly-energy-sector-cyber-attacks",
+            "date": "20 October 2017",
+            "source_file": "GroupProfiles/BERSERKBEAR.md"
+          },
+          {
+            "title": "www.secureworks.com",
+            "url": "https://www.secureworks.com/research/resurgent-iron-liberty-targeting-energy-sector",
+            "date": "24 July 2019",
+            "source_file": "GroupProfiles/BERSERKBEAR.md"
+          },
+          {
+            "title": "www.gov.uk",
+            "url": "https://www.gov.uk/government/news/uk-exposes-russian-spy-agency-behind-cyber-incidents",
+            "date": "24 March 2022",
+            "source_file": "GroupProfiles/BERSERKBEAR.md"
+          }
+        ],
+        "source_attribution": "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence.",
+        "source_dataset_url": "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1",
+        "source_files": [
+          "GroupProfiles/BERSERKBEAR.md",
+          "Other/ThreatIntelligence.md",
+          "Tools/CredentialTheft.md",
+          "Tools/Discovery.md",
+          "Tools/LOLBAS.md",
+          "Tools/Networking.md",
+          "Tools/Offsec.md",
+          "Tools/RMM-Tools.md"
+        ],
+        "source_label": "BERSERK BEAR",
+        "source_repository": "https://github.com/BushidoUK/Russian-APT-Tool-Matrix",
+        "source_retrieved_at": "2026-04-28T02:07:35Z",
+        "tools_by_category": {
+          "Credential Theft": [
+            "Mimikatz",
+            "ProcDump"
+          ],
+          "Discovery": [
+            "Angry IP Scanner"
+          ],
+          "LOLBAS": [
+            "BITSAdmin",
+            "PsExec"
+          ],
+          "Networking": [
+            "FortiClient"
+          ],
+          "OffSec": [
+            "CrackMapExec",
+            "Hydra",
+            "Impacket",
+            "Phishery"
+          ],
+          "RMM Tools": [
+            "TeamViewer"
+          ]
+        }
       }
     },
     "page_path": "_threat_actors/apt0035.md",
@@ -6523,7 +6690,7 @@
     ],
     "first_seen": null,
     "last_activity": null,
-    "last_updated": null,
+    "last_updated": "2026-04-28",
     "risk_level": null,
     "source_name": null,
     "source_attribution": "© The MITRE Corporation. This work is reproduced and distributed with the permission of The MITRE Corporation.",
@@ -6535,6 +6702,65 @@
         "source_dataset_url": "https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack.json",
         "source_record_id": "G0047",
         "source_retrieved_at": "2026-04-26T07:05:44Z"
+      },
+      "russian_apt_tool_matrix": {
+        "references": [
+          {
+            "title": "harfanglab.io",
+            "url": "https://harfanglab.io/insidethelab/gamaredons-pterolnk-analysis/",
+            "date": "16 April 2025",
+            "source_file": "Other/ThreatIntelligence.md"
+          },
+          {
+            "title": "www.welivesecurity.com",
+            "url": "https://www.welivesecurity.com/en/eset-research/cyberespionage-gamaredon-way-analysis-toolset-used-spy-ukraine-2022-2023",
+            "date": "26 September 2024",
+            "source_file": "GroupProfiles/Gamaredon.md"
+          },
+          {
+            "title": "ssu.gov.ua",
+            "url": "https://ssu.gov.ua/uploads/files/DKIB/Technical%20report%20Armagedon.pdf",
+            "date": "4 November 2021",
+            "source_file": "GroupProfiles/Gamaredon.md"
+          }
+        ],
+        "source_attribution": "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence.",
+        "source_dataset_url": "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1",
+        "source_files": [
+          "GroupProfiles/Gamaredon.md",
+          "Other/ThreatIntelligence.md",
+          "Tools/CredentialTheft.md",
+          "Tools/Exfiltration.md",
+          "Tools/LOLBAS.md",
+          "Tools/Networking.md",
+          "Tools/RMM-Tools.md"
+        ],
+        "source_label": "Gamaredon",
+        "source_repository": "https://github.com/BushidoUK/Russian-APT-Tool-Matrix",
+        "source_retrieved_at": "2026-04-28T02:07:35Z",
+        "tools_by_category": {
+          "Credential Theft": [
+            "Mimikatz"
+          ],
+          "Exfiltration": [
+            "Rclone",
+            "Telegram"
+          ],
+          "LOLBAS": [
+            "PsExec"
+          ],
+          "Networking": [
+            "Cloudflared",
+            "Ngrok",
+            "telegra[.]ph",
+            "teletype[.]in",
+            "trycloudflare[.]com"
+          ],
+          "RMM Tools": [
+            "Remote Manipulator System (RMS)",
+            "UltraVNC"
+          ]
+        }
       }
     },
     "page_path": "_threat_actors/apt0047.md",
@@ -13517,7 +13743,7 @@
     ],
     "first_seen": null,
     "last_activity": null,
-    "last_updated": null,
+    "last_updated": "2026-04-28",
     "risk_level": null,
     "source_name": null,
     "source_attribution": "© The MITRE Corporation. This work is reproduced and distributed with the permission of The MITRE Corporation.",
@@ -13529,6 +13755,69 @@
         "source_dataset_url": "https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack.json",
         "source_record_id": "G1003",
         "source_retrieved_at": "2026-04-26T05:01:37Z"
+      },
+      "russian_apt_tool_matrix": {
+        "references": [
+          {
+            "title": "www.cisa.gov",
+            "url": "https://www.cisa.gov/news-events/cybersecurity-advisories/aa24-249a",
+            "date": "5 September 2024",
+            "source_file": "GroupProfiles/EMBERBEAR.md"
+          }
+        ],
+        "source_attribution": "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence.",
+        "source_dataset_url": "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1",
+        "source_files": [
+          "GroupProfiles/EMBERBEAR.md",
+          "Other/ThreatIntelligence.md",
+          "Tools/Discovery.md",
+          "Tools/Exfiltration.md",
+          "Tools/LOLBAS.md",
+          "Tools/Networking.md",
+          "Tools/Offsec.md"
+        ],
+        "source_label": "EMBER BEAR",
+        "source_repository": "https://github.com/BushidoUK/Russian-APT-Tool-Matrix",
+        "source_retrieved_at": "2026-04-28T02:07:35Z",
+        "tools_by_category": {
+          "Discovery": [
+            "Acunetix",
+            "Adminer",
+            "Amass",
+            "Bloodhound",
+            "Droopescan",
+            "JoomScan",
+            "LdapDomainDump",
+            "Masscan",
+            "Nmap",
+            "WPScan"
+          ],
+          "Exfiltration": [
+            "MEGA",
+            "Rclone"
+          ],
+          "LOLBAS": [
+            "PsExec"
+          ],
+          "Networking": [
+            "GOST",
+            "Iodine",
+            "ProxyChains",
+            "ReGeorg",
+            "dnscat2"
+          ],
+          "OffSec": [
+            "CrackMapExec",
+            "Impacket",
+            "LinPEAS",
+            "Metasploit",
+            "Meterpreter",
+            "NetCat",
+            "PAS Web Shell",
+            "Responder",
+            "WSO Web Shell"
+          ]
+        }
       }
     },
     "page_path": "_threat_actors/apt1003.md",
@@ -18851,7 +19140,7 @@
     ],
     "first_seen": "2007",
     "last_activity": "2024",
-    "last_updated": "2026-04-27",
+    "last_updated": "2026-04-28",
     "risk_level": "High",
     "source_name": "Malpedia (Fraunhofer FKIE)",
     "source_attribution": "© The MITRE Corporation. This work is reproduced and distributed with the permission of The MITRE Corporation.",
@@ -18929,6 +19218,112 @@
         "source_dataset_url": "https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack.json",
         "source_record_id": "G0007",
         "source_retrieved_at": "2026-04-26T07:05:44Z"
+      },
+      "russian_apt_tool_matrix": {
+        "references": [
+          {
+            "title": "media.defense.gov",
+            "url": "https://media.defense.gov/2021/Jul/01/2002753896/-1/-1/1/CSA_GRU_GLOBAL_BRUTE_FORCE_CAMPAIGN_UOO158036-21.PDF",
+            "date": "1 July 2021",
+            "source_file": "GroupProfiles/FANCYBEAR.md"
+          },
+          {
+            "title": "www.trendmicro.com",
+            "url": "https://www.trendmicro.com/en_us/research/24/e/router-roulette.html",
+            "date": "1 May 2024",
+            "source_file": "Other/ThreatIntelligence.md"
+          },
+          {
+            "title": "www.microsoft.com",
+            "url": "https://www.microsoft.com/en-us/security/blog/2020/09/10/strontium-detecting-new-patters-credential-harvesting/",
+            "date": "10 September 2020",
+            "source_file": "GroupProfiles/FANCYBEAR.md"
+          },
+          {
+            "title": "web.archive.org",
+            "url": "https://web.archive.org/web/20170811181009/https://www.fireeye.com/blog/threat-research/2017/08/apt28-targets-hospitality-sector.html",
+            "date": "11 August 2017",
+            "source_file": "GroupProfiles/FANCYBEAR.md"
+          },
+          {
+            "title": "cloud.google.com",
+            "url": "https://cloud.google.com/blog/topics/threat-intelligence/probable-apt28-useo/",
+            "date": "18 April 2015",
+            "source_file": "GroupProfiles/FANCYBEAR.md"
+          },
+          {
+            "title": "www.cisa.gov",
+            "url": "https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-108",
+            "date": "18 April 2018",
+            "source_file": "GroupProfiles/FANCYBEAR.md"
+          },
+          {
+            "title": "cert.gov.ua",
+            "url": "https://cert.gov.ua/article/6281123",
+            "date": "25 October 2024",
+            "source_file": "GroupProfiles/FANCYBEAR.md"
+          },
+          {
+            "title": "cert.gov.ua",
+            "url": "https://cert.gov.ua/article/6276894",
+            "date": "28 December 2023",
+            "source_file": "GroupProfiles/FANCYBEAR.md"
+          },
+          {
+            "title": "securelist.com",
+            "url": "https://securelist.com/sofacy-apt-hits-high-profile-targets-with-updated-toolset/72924/",
+            "date": "4 December 2015",
+            "source_file": "GroupProfiles/FANCYBEAR.md"
+          },
+          {
+            "title": "unit42.paloaltonetworks.com",
+            "url": "https://unit42.paloaltonetworks.com/unit42-sofacy-groups-parallel-attacks/",
+            "date": "6 June 2018",
+            "source_file": "GroupProfiles/FANCYBEAR.md"
+          },
+          {
+            "title": "securityintelligence.com",
+            "url": "https://securityintelligence.com/x-force/itg05-ops-leverage-israel-hamas-conflict-lures-to-deliver-headlace-malware/",
+            "date": "8 December 2023",
+            "source_file": "GroupProfiles/FANCYBEAR.md"
+          }
+        ],
+        "source_attribution": "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence.",
+        "source_dataset_url": "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1",
+        "source_files": [
+          "GroupProfiles/FANCYBEAR.md",
+          "Other/ThreatIntelligence.md",
+          "Tools/CredentialTheft.md",
+          "Tools/LOLBAS.md",
+          "Tools/Networking.md",
+          "Tools/Offsec.md"
+        ],
+        "source_label": "FANCY BEAR",
+        "source_repository": "https://github.com/BushidoUK/Russian-APT-Tool-Matrix",
+        "source_retrieved_at": "2026-04-28T02:07:35Z",
+        "tools_by_category": {
+          "Credential Theft": [
+            "Mimikatz"
+          ],
+          "LOLBAS": [
+            "MiniDump",
+            "Windows Event Utility (wevtutil)"
+          ],
+          "Networking": [
+            "OpenSSH",
+            "ReGeorg",
+            "SSHDoor"
+          ],
+          "OffSec": [
+            "Empyre",
+            "Impacket",
+            "Koadic",
+            "Metasploit",
+            "Nishang",
+            "PowerShell Empire",
+            "Responder"
+          ]
+        }
       }
     },
     "page_path": "_threat_actors/apt28.md",
@@ -19490,7 +19885,7 @@
     ],
     "first_seen": "2008",
     "last_activity": "2024",
-    "last_updated": "2026-04-27",
+    "last_updated": "2026-04-28",
     "risk_level": "High",
     "source_name": null,
     "source_attribution": "© The MITRE Corporation. This work is reproduced and distributed with the permission of The MITRE Corporation.",
@@ -19499,10 +19894,6 @@
     "source_license_url": null,
     "provenance": {
       "bushido_breach_reports": {
-        "source_repository": "https://github.com/BushidoUK/Breach-Report-Collection",
-        "source_dataset_url": "https://raw.githubusercontent.com/BushidoUK/Breach-Report-Collection/main/README.md",
-        "source_attribution": "References were identified via the BushidoToken Breach Report Collection (https://github.com/BushidoUK/Breach-Report-Collection), which is used here as a report index. Copyright in linked reports remains with the original publishers.",
-        "source_retrieved_at": "2026-04-28T01:40:03Z",
         "reports": [
           {
             "organization": "Microsoft",
@@ -19549,12 +19940,150 @@
               "https://web.archive.org/web/20230209021934/https://orangematter.solarwinds.com/2021/01/11/new-findings-from-our-investigation-of-sunburst/"
             ]
           }
-        ]
+        ],
+        "source_attribution": "References were identified via the BushidoToken Breach Report Collection (https://github.com/BushidoUK/Breach-Report-Collection), which is used here as a report index. Copyright in linked reports remains with the original publishers.",
+        "source_dataset_url": "https://raw.githubusercontent.com/BushidoUK/Breach-Report-Collection/main/README.md",
+        "source_repository": "https://github.com/BushidoUK/Breach-Report-Collection",
+        "source_retrieved_at": "2026-04-28T01:40:03Z"
       },
       "mitre": {
         "source_dataset_url": "https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack.json",
         "source_record_id": "G0016",
         "source_retrieved_at": "2026-04-26T05:24:31Z"
+      },
+      "russian_apt_tool_matrix": {
+        "references": [
+          {
+            "title": "www.cisa.gov",
+            "url": "https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-347a",
+            "date": "13 December 2023",
+            "source_file": "GroupProfiles/COZYBEAR.md"
+          },
+          {
+            "title": "www.gov.uk",
+            "url": "https://www.gov.uk/government/news/russia-uk-and-us-expose-global-campaigns-of-malign-activity-by-russian-intelligence-services",
+            "date": "15 April 2021",
+            "source_file": "GroupProfiles/COZYBEAR.md"
+          },
+          {
+            "title": "research.checkpoint.com",
+            "url": "https://research.checkpoint.com/2025/apt29-phishing-campaign/",
+            "date": "15 April 2025",
+            "source_file": "Other/ThreatIntelligence.md"
+          },
+          {
+            "title": "www.microsoft.com",
+            "url": "https://www.microsoft.com/en-us/security/blog/2020/12/18/analyzing-solorigate-the-compromised-dll-file-that-started-a-sophisticated-cyberattack-and-how-microsoft-defender-helps-protect/",
+            "date": "18 December 2020",
+            "source_file": "GroupProfiles/COZYBEAR.md"
+          },
+          {
+            "title": "www.cert.ssi.gouv.fr",
+            "url": "https://www.cert.ssi.gouv.fr/cti/CERTFR-2024-CTI-006/",
+            "date": "19 June 2024",
+            "source_file": "Other/ThreatIntelligence.md"
+          },
+          {
+            "title": "cloud.google.com",
+            "url": "https://cloud.google.com/blog/topics/threat-intelligence/unc3524-eye-spy-email/",
+            "date": "2 May 2022",
+            "source_file": "GroupProfiles/COZYBEAR.md"
+          },
+          {
+            "title": "www.microsoft.com",
+            "url": "https://www.microsoft.com/en-us/security/blog/2021/10/25/nobelium-targeting-delegated-administrative-privileges-to-facilitate-broader-attacks/",
+            "date": "25 October 2021",
+            "source_file": "GroupProfiles/COZYBEAR.md"
+          },
+          {
+            "title": "www.zscaler.com",
+            "url": "https://www.zscaler.com/blogs/security-research/european-diplomats-targeted-apt29-cozy-bear-wineloader",
+            "date": "27 February 2024",
+            "source_file": "Other/ThreatIntelligence.md"
+          },
+          {
+            "title": "www.crowdstrike.com",
+            "url": "https://www.crowdstrike.com/blog/observations-from-the-stellarparticle-campaign/",
+            "date": "27 January 2022",
+            "source_file": "GroupProfiles/COZYBEAR.md"
+          },
+          {
+            "title": "go.recordedfuture.com",
+            "url": "https://go.recordedfuture.com/hubfs/reports/cta-2023-0127.pdf",
+            "date": "27 January 2023",
+            "source_file": "GroupProfiles/COZYBEAR.md"
+          },
+          {
+            "title": "www.microsoft.com",
+            "url": "https://www.microsoft.com/en-us/security/blog/2021/05/27/new-sophisticated-email-based-attack-from-nobelium/",
+            "date": "27 May 2021",
+            "source_file": "GroupProfiles/COZYBEAR.md"
+          }
+        ],
+        "source_attribution": "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence.",
+        "source_dataset_url": "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1",
+        "source_files": [
+          "GroupProfiles/COZYBEAR.md",
+          "Other/ThreatIntelligence.md",
+          "Tools/CredentialTheft.md",
+          "Tools/DefenseEvasion.md",
+          "Tools/Discovery.md",
+          "Tools/Exfiltration.md",
+          "Tools/LOLBAS.md",
+          "Tools/Networking.md",
+          "Tools/Offsec.md"
+        ],
+        "source_label": "COZY BEAR",
+        "source_repository": "https://github.com/BushidoUK/Russian-APT-Tool-Matrix",
+        "source_retrieved_at": "2026-04-28T02:07:35Z",
+        "tools_by_category": {
+          "Credential Theft": [
+            "CookieEditor",
+            "Mimikatz",
+            "SharpChormium",
+            "SharpChromium"
+          ],
+          "Defense Evasion": [
+            "EDRSandBlast",
+            "VMware Tools (DLL side-loading)"
+          ],
+          "Discovery": [
+            "AADInternals",
+            "AdFind",
+            "Bloodhound",
+            "DSInternals",
+            "RoadTools"
+          ],
+          "Exfiltration": [
+            "Dropbox",
+            "Firebase",
+            "Google Drive",
+            "Notion",
+            "OneDrive",
+            "Trello"
+          ],
+          "LOLBAS": [
+            "PowerPoint.exe (DLL side-loading)",
+            "PsExec",
+            "WMIC",
+            "sqlwriter.exe (DLL side-loading)"
+          ],
+          "Networking": [
+            "Dropbear",
+            "ReGeorg",
+            "Rosockstun",
+            "Rsockstun"
+          ],
+          "OffSec": [
+            "Brute Ratel C4",
+            "Cobalt Strike",
+            "Impacket",
+            "PowerSploit",
+            "Rubeus",
+            "Sliver",
+            "WinPEAS"
+          ]
+        }
       }
     },
     "page_path": "_threat_actors/apt29.md",
@@ -30086,7 +30615,7 @@
     ],
     "first_seen": null,
     "last_activity": null,
-    "last_updated": null,
+    "last_updated": "2026-04-28",
     "risk_level": null,
     "source_name": null,
     "source_attribution": "Data sourced from MISP Galaxy threat-actor cluster (CC0 licensed)",
@@ -30098,6 +30627,37 @@
         "source_dataset_url": "https://raw.githubusercontent.com/MISP/misp-galaxy/main/clusters/threat-actor.json",
         "source_record_id": "7d99d2f7-adf0-44e4-9044-d18ff6842a16",
         "source_retrieved_at": "2026-04-26T05:47:15Z"
+      },
+      "russian_apt_tool_matrix": {
+        "references": [
+          {
+            "title": "citizenlab.ca",
+            "url": "https://citizenlab.ca/2024/08/sophisticated-phishing-targets-russias-perceived-enemies-around-the-globe/",
+            "date": "14 August 2024",
+            "source_file": "GroupProfiles/COLDRIVER.md"
+          },
+          {
+            "title": "www.ncsc.gov.uk",
+            "url": "https://www.ncsc.gov.uk/news/uk-and-allies-expose-cyber-campaign-attempted-political-interference",
+            "date": "7 December 2023",
+            "source_file": "GroupProfiles/COLDRIVER.md"
+          }
+        ],
+        "source_attribution": "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence.",
+        "source_dataset_url": "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1",
+        "source_files": [
+          "GroupProfiles/COLDRIVER.md",
+          "Other/ThreatIntelligence.md",
+          "Tools/Offsec.md"
+        ],
+        "source_label": "COLDRIVER / Star Blizzard",
+        "source_repository": "https://github.com/BushidoUK/Russian-APT-Tool-Matrix",
+        "source_retrieved_at": "2026-04-28T02:07:35Z",
+        "tools_by_category": {
+          "OffSec": [
+            "EvilGinx"
+          ]
+        }
       }
     },
     "page_path": "_threat_actors/cold-river.md",
@@ -32000,7 +32560,7 @@
     ],
     "first_seen": null,
     "last_activity": null,
-    "last_updated": null,
+    "last_updated": "2026-04-28",
     "risk_level": null,
     "source_name": null,
     "source_attribution": "Data sourced from MISP Galaxy threat-actor cluster (CC0 licensed)",
@@ -32012,6 +32572,55 @@
         "source_dataset_url": "https://raw.githubusercontent.com/MISP/misp-galaxy/main/clusters/threat-actor.json",
         "source_record_id": "7bf6ae38-fcd3-4a99-99ba-292990a27f0a",
         "source_retrieved_at": "2026-04-26T05:47:15Z"
+      },
+      "russian_apt_tool_matrix": {
+        "references": [
+          {
+            "title": "businessinsights.bitdefender.com",
+            "url": "https://businessinsights.bitdefender.com/curly-comrades-new-threat-actor-targeting-geopolitical-hotbeds",
+            "date": "12 August 2025",
+            "source_file": "Other/ThreatIntelligence.md"
+          }
+        ],
+        "source_attribution": "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence.",
+        "source_dataset_url": "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1",
+        "source_files": [
+          "Other/ThreatIntelligence.md",
+          "Tools/CredentialTheft.md",
+          "Tools/DefenseEvasion.md",
+          "Tools/LOLBAS.md",
+          "Tools/Networking.md",
+          "Tools/Offsec.md",
+          "Tools/RMM-Tools.md"
+        ],
+        "source_label": "Curly COMrades",
+        "source_repository": "https://github.com/BushidoUK/Russian-APT-Tool-Matrix",
+        "source_retrieved_at": "2026-04-28T02:07:35Z",
+        "tools_by_category": {
+          "Credential Theft": [
+            "Mimikatz",
+            "ProcDump",
+            "TrickDump"
+          ],
+          "Defense Evasion": [
+            "Garble"
+          ],
+          "LOLBAS": [
+            "DCSync",
+            "curl"
+          ],
+          "Networking": [
+            "Resocks",
+            "SOCKS5",
+            "stunnel"
+          ],
+          "OffSec": [
+            "Impacket"
+          ],
+          "RMM Tools": [
+            "RemoteUtilities"
+          ]
+        }
       }
     },
     "page_path": "_threat_actors/curly-comrades.md",
@@ -70350,7 +70959,7 @@
     ],
     "first_seen": null,
     "last_activity": null,
-    "last_updated": "2026-04-27",
+    "last_updated": "2026-04-28",
     "risk_level": "High",
     "source_name": null,
     "source_attribution": "Data sourced from MISP Galaxy threat-actor cluster (CC0 licensed)",
@@ -70359,10 +70968,6 @@
     "source_license_url": null,
     "provenance": {
       "bushido_breach_reports": {
-        "source_repository": "https://github.com/BushidoUK/Breach-Report-Collection",
-        "source_dataset_url": "https://raw.githubusercontent.com/BushidoUK/Breach-Report-Collection/main/README.md",
-        "source_attribution": "References were identified via the BushidoToken Breach Report Collection (https://github.com/BushidoUK/Breach-Report-Collection), which is used here as a report index. Copyright in linked reports remains with the original publishers.",
-        "source_retrieved_at": "2026-04-28T01:40:03Z",
         "reports": [
           {
             "organization": "Viasat KA-SAT",
@@ -70375,12 +70980,94 @@
               "https://web.archive.org/web/20230407225107/https://news.viasat.com/blog/corporate/ka-sat-network-cyber-attack-overview"
             ]
           }
-        ]
+        ],
+        "source_attribution": "References were identified via the BushidoToken Breach Report Collection (https://github.com/BushidoUK/Breach-Report-Collection), which is used here as a report index. Copyright in linked reports remains with the original publishers.",
+        "source_dataset_url": "https://raw.githubusercontent.com/BushidoUK/Breach-Report-Collection/main/README.md",
+        "source_repository": "https://github.com/BushidoUK/Breach-Report-Collection",
+        "source_retrieved_at": "2026-04-28T01:40:03Z"
       },
       "misp_galaxy": {
         "source_dataset_url": "https://raw.githubusercontent.com/MISP/misp-galaxy/main/clusters/threat-actor.json",
         "source_record_id": "f512de42-f76b-40d2-9923-59e7dbdfec35",
         "source_retrieved_at": "2026-04-26T05:47:15Z"
+      },
+      "russian_apt_tool_matrix": {
+        "references": [
+          {
+            "title": "www.microsoft.com",
+            "url": "https://www.microsoft.com/en-us/security/blog/2025/02/12/the-badpilot-campaign-seashell-blizzard-subgroup-conducts-multiyear-global-access-operation/",
+            "date": "12 February 2025",
+            "source_file": "GroupProfiles/Sandworm.md"
+          },
+          {
+            "title": "services.google.com",
+            "url": "https://services.google.com/fh/files/misc/apt44-unearthing-sandworm.pdf",
+            "date": "17 April 2024",
+            "source_file": "GroupProfiles/Sandworm.md"
+          },
+          {
+            "title": "cert.gov.ua",
+            "url": "https://cert.gov.ua/article/6278706",
+            "date": "19 April 2024",
+            "source_file": "GroupProfiles/Sandworm.md"
+          }
+        ],
+        "source_attribution": "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence.",
+        "source_dataset_url": "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1",
+        "source_files": [
+          "GroupProfiles/Sandworm.md",
+          "Other/ThreatIntelligence.md",
+          "Tools/DefenseEvasion.md",
+          "Tools/Exfiltration.md",
+          "Tools/LOLBAS.md",
+          "Tools/Networking.md",
+          "Tools/Offsec.md",
+          "Tools/RMM-Tools.md"
+        ],
+        "source_label": "Sandworm",
+        "source_repository": "https://github.com/BushidoUK/Russian-APT-Tool-Matrix",
+        "source_retrieved_at": "2026-04-28T02:07:35Z",
+        "tools_by_category": {
+          "Defense Evasion": [
+            "SDelete",
+            "libprocesshider"
+          ],
+          "Exfiltration": [
+            "Rclone"
+          ],
+          "LOLBAS": [
+            "BITSAdmin",
+            "BITSadmin",
+            "certutil",
+            "curl"
+          ],
+          "Networking": [
+            "Chisel",
+            "OpenSSH",
+            "Pivotnacci",
+            "ReGeorg",
+            "Tor"
+          ],
+          "OffSec": [
+            "Cobalt Strike",
+            "Empyre",
+            "Impacket",
+            "JuicyPotatoNG",
+            "Metasploit",
+            "Meterpreter",
+            "PAS Web Shell",
+            "PoshC2",
+            "PowerShell Empire",
+            "RottenPotatoNG",
+            "WSO Web Shell",
+            "Weevely Web Shell"
+          ],
+          "RMM Tools": [
+            "Atera",
+            "RemCom",
+            "Splashtop"
+          ]
+        }
       }
     },
     "page_path": "_threat_actors/sandworm.md",
@@ -97586,7 +98273,7 @@
     ],
     "first_seen": null,
     "last_activity": null,
-    "last_updated": null,
+    "last_updated": "2026-04-28",
     "risk_level": null,
     "source_name": null,
     "source_attribution": "Data sourced from MISP Galaxy threat-actor cluster (CC0 licensed)",
@@ -97598,6 +98285,31 @@
         "source_dataset_url": "https://raw.githubusercontent.com/MISP/misp-galaxy/main/clusters/threat-actor.json",
         "source_record_id": "63305373-15a8-4f84-ab09-27ffeaa99ae2",
         "source_retrieved_at": "2026-04-26T05:47:15Z"
+      },
+      "russian_apt_tool_matrix": {
+        "references": [
+          {
+            "title": "www.volexity.com",
+            "url": "https://www.volexity.com/blog/2025/04/22/phishing-for-codes-russian-threat-actors-target-microsoft-365-oauth-workflows/",
+            "date": "22 April 2025",
+            "source_file": "Other/ThreatIntelligence.md"
+          }
+        ],
+        "source_attribution": "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence.",
+        "source_dataset_url": "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1",
+        "source_files": [
+          "Other/ThreatIntelligence.md",
+          "Tools/Networking.md"
+        ],
+        "source_label": "UTA0352 / UTA0352, UTA0355",
+        "source_repository": "https://github.com/BushidoUK/Russian-APT-Tool-Matrix",
+        "source_retrieved_at": "2026-04-28T02:07:35Z",
+        "tools_by_category": {
+          "Networking": [
+            "insiders[.]vscode[.]dev",
+            "vscode-redirect[.]azurewebsites.net"
+          ]
+        }
       }
     },
     "page_path": "_threat_actors/uta0352.md",
@@ -97662,7 +98374,7 @@
     ],
     "first_seen": null,
     "last_activity": null,
-    "last_updated": null,
+    "last_updated": "2026-04-28",
     "risk_level": null,
     "source_name": null,
     "source_attribution": "Data sourced from MISP Galaxy threat-actor cluster (CC0 licensed)",
@@ -97674,6 +98386,24 @@
         "source_dataset_url": "https://raw.githubusercontent.com/MISP/misp-galaxy/main/clusters/threat-actor.json",
         "source_record_id": "b4bbbd06-a204-4363-90d2-f38cc0def521",
         "source_retrieved_at": "2026-04-26T05:47:15Z"
+      },
+      "russian_apt_tool_matrix": {
+        "references": [
+          {
+            "title": "www.volexity.com",
+            "url": "https://www.volexity.com/blog/2025/04/22/phishing-for-codes-russian-threat-actors-target-microsoft-365-oauth-workflows/",
+            "date": "22 April 2025",
+            "source_file": "Other/ThreatIntelligence.md"
+          }
+        ],
+        "source_attribution": "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence.",
+        "source_dataset_url": "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1",
+        "source_files": [
+          "Other/ThreatIntelligence.md"
+        ],
+        "source_label": "UTA0352, UTA0355",
+        "source_repository": "https://github.com/BushidoUK/Russian-APT-Tool-Matrix",
+        "source_retrieved_at": "2026-04-28T02:07:35Z"
       }
     },
     "page_path": "_threat_actors/uta0355.md",
@@ -99642,7 +100372,7 @@
     ],
     "first_seen": null,
     "last_activity": null,
-    "last_updated": null,
+    "last_updated": "2026-04-28",
     "risk_level": null,
     "source_name": null,
     "source_attribution": "Data sourced from MISP Galaxy threat-actor cluster (CC0 licensed)",
@@ -99654,6 +100384,34 @@
         "source_dataset_url": "https://raw.githubusercontent.com/MISP/misp-galaxy/main/clusters/threat-actor.json",
         "source_record_id": "b495419f-e327-4bbe-aba5-0c281dc2605b",
         "source_retrieved_at": "2026-04-26T05:47:15Z"
+      },
+      "russian_apt_tool_matrix": {
+        "references": [
+          {
+            "title": "www.microsoft.com",
+            "url": "https://www.microsoft.com/en-us/security/blog/2025/05/27/new-russia-affiliated-actor-void-blizzard-targets-critical-sectors-for-espionage/",
+            "date": "27 May 2025",
+            "source_file": "Other/ThreatIntelligence.md"
+          }
+        ],
+        "source_attribution": "Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence.",
+        "source_dataset_url": "https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1",
+        "source_files": [
+          "Other/ThreatIntelligence.md",
+          "Tools/Discovery.md",
+          "Tools/Offsec.md"
+        ],
+        "source_label": "Void Blizzard / Void Blizzard/LAUNDRY BEAR",
+        "source_repository": "https://github.com/BushidoUK/Russian-APT-Tool-Matrix",
+        "source_retrieved_at": "2026-04-28T02:07:35Z",
+        "tools_by_category": {
+          "Discovery": [
+            "AzureHound"
+          ],
+          "OffSec": [
+            "EvilGinx"
+          ]
+        }
       }
     },
     "page_path": "_threat_actors/void-blizzard.md",

--- a/_threat_actors/apt0010.md
+++ b/_threat_actors/apt0010.md
@@ -94,6 +94,18 @@ Turla is a cyber espionage threat group that has been attributed to Russia's Fed
 - **MiniDionis**
 - **WhiteBear**
 
+### Russian APT Tool Matrix observations
+| Category | Observed tools |
+|---|---|
+| Credential Theft | Mimikatz |
+| Defense Evasion | PowerShellRunner, VirtualBox Driver |
+| Discovery | NBTScan, SScan |
+| Exfiltration | 4Shared, Dropbox, GMX, Gmail, OneDrive, VFEmail |
+| LOLBAS | PsExec |
+| Networking | Chisel |
+| OffSec | Evil-WinRM, Metapsloit, Metasploit, PowerShell Empire, PowerSploit |
+| RMM Tools | IntelliAdmin |
+
 ## Attribution and Evidence
 **Country of Origin**: Russia
 *Additional attribution information pending cataloguing.*

--- a/_threat_actors/apt0035.md
+++ b/_threat_actors/apt0035.md
@@ -22,7 +22,15 @@ Dragonfly is a cyber espionage group that has been attributed to Russia's Federa
 *No curated IOCs are currently published for this actor. This section will be updated when stable, attributable indicators are available.*
 
 ## Malware and Tools
-*Information pending cataloguing.*
+### Russian APT Tool Matrix observations
+| Category | Observed tools |
+|---|---|
+| Credential Theft | Mimikatz, ProcDump |
+| Discovery | Angry IP Scanner |
+| LOLBAS | BITSAdmin, PsExec |
+| Networking | FortiClient |
+| OffSec | CrackMapExec, Hydra, Impacket, Phishery |
+| RMM Tools | TeamViewer |
 
 ## Attribution and Evidence
 *Information pending cataloguing.*

--- a/_threat_actors/apt0047.md
+++ b/_threat_actors/apt0047.md
@@ -32,6 +32,15 @@ Gamaredon Group is a suspected Russian cyber espionage group that has targeted m
 ## Malware and Tools
 - **Archelaus Beta**
 
+### Russian APT Tool Matrix observations
+| Category | Observed tools |
+|---|---|
+| Credential Theft | Mimikatz |
+| Exfiltration | Rclone, Telegram |
+| LOLBAS | PsExec |
+| Networking | Cloudflared, Ngrok, telegra[.]ph, teletype[.]in, trycloudflare[.]com |
+| RMM Tools | Remote Manipulator System (RMS), UltraVNC |
+
 ## Attribution and Evidence
 **Country of Origin**: Russia
 *Additional attribution information pending cataloguing.*

--- a/_threat_actors/apt1003.md
+++ b/_threat_actors/apt1003.md
@@ -22,7 +22,14 @@ Ember Bear is a Russian state-sponsored cyber espionage group that has been acti
 *No curated IOCs are currently published for this actor. This section will be updated when stable, attributable indicators are available.*
 
 ## Malware and Tools
-*Information pending cataloguing.*
+### Russian APT Tool Matrix observations
+| Category | Observed tools |
+|---|---|
+| Discovery | Acunetix, Adminer, Amass, Bloodhound, Droopescan, JoomScan, LdapDomainDump, Masscan, Nmap, WPScan |
+| Exfiltration | MEGA, Rclone |
+| LOLBAS | PsExec |
+| Networking | GOST, Iodine, ProxyChains, ReGeorg, dnscat2 |
+| OffSec | CrackMapExec, Impacket, LinPEAS, Metasploit, Meterpreter, NetCat, PAS Web Shell, Responder, WSO Web Shell |
 
 ## Attribution and Evidence
 *Information pending cataloguing.*

--- a/_threat_actors/apt28.md
+++ b/_threat_actors/apt28.md
@@ -75,6 +75,14 @@ APT28 is a threat group that has been attributed to Russia's General Staff Main 
 - **Unidentified JS 007 (Zimbra Stealer)**
 - **PixyNetLoader**
 
+### Russian APT Tool Matrix observations
+| Category | Observed tools |
+|---|---|
+| Credential Theft | Mimikatz |
+| LOLBAS | MiniDump, Windows Event Utility (wevtutil) |
+| Networking | OpenSSH, ReGeorg, SSHDoor |
+| OffSec | Empyre, Impacket, Koadic, Metasploit, Nishang, PowerShell Empire, Responder |
+
 ## Attribution and Evidence
 **Country of Origin**: Russia
 *Additional attribution information pending cataloguing.*

--- a/_threat_actors/apt29.md
+++ b/_threat_actors/apt29.md
@@ -45,6 +45,17 @@ APT29 is threat group that has been attributed to Russia's Foreign Intelligence 
 - **OnionDuke**
 - **CyberGate**
 
+### Russian APT Tool Matrix observations
+| Category | Observed tools |
+|---|---|
+| Credential Theft | CookieEditor, Mimikatz, SharpChormium, SharpChromium |
+| Defense Evasion | EDRSandBlast, VMware Tools (DLL side-loading) |
+| Discovery | AADInternals, AdFind, Bloodhound, DSInternals, RoadTools |
+| Exfiltration | Dropbox, Firebase, Google Drive, Notion, OneDrive, Trello |
+| LOLBAS | PowerPoint.exe (DLL side-loading), PsExec, WMIC, sqlwriter.exe (DLL side-loading) |
+| Networking | Dropbear, ReGeorg, Rosockstun, Rsockstun |
+| OffSec | Brute Ratel C4, Cobalt Strike, Impacket, PowerSploit, Rubeus, Sliver, WinPEAS |
+
 ## Attribution and Evidence
 **Country of Origin**: Russia
 *Additional attribution information pending cataloguing.*
@@ -52,16 +63,4 @@ APT29 is threat group that has been attributed to Russia's Foreign Intelligence 
 ## References
 [1] [MITRE ATT&CK](https://attack.mitre.org/groups/G0016)
    MITRE ATT&CK entry
-
-
-[2] [BushidoToken Breach Report Collection - Microsoft breach report (January 2024) via microsoft.com (1)](https://www.microsoft.com/en-us/security/blog/2024/01/25/midnight-blizzard-guidance-for-responders-on-nation-state-attack/)
-   Source index: https://github.com/BushidoUK/Breach-Report-Collection; adversary label: CozyBear (RU APT).
-[3] [BushidoToken Breach Report Collection - Microsoft breach report (January 2024) via microsoft.com (2)](https://msrc.microsoft.com/blog/2024/03/update-on-microsoft-actions-following-attack-by-nation-state-actor-midnight-blizzard/)
-   Source index: https://github.com/BushidoUK/Breach-Report-Collection; adversary label: CozyBear (RU APT).
-[4] [BushidoToken Breach Report Collection - Microsoft breach report (February 2021) via msrc.microsoft.com](https://msrc.microsoft.com/blog/2021/02/microsoft-internal-solorigate-investigation-final-update/)
-   Source index: https://github.com/BushidoUK/Breach-Report-Collection; adversary label: CozyBear (RU APT).
-[5] [BushidoToken Breach Report Collection - FireEye breach report (December 2020) via fireeye.com](https://www.fireeye.com/blog/threat-research/2020/12/unauthorized-access-of-fireeye-red-team-tools.html)
-   Source index: https://github.com/BushidoUK/Breach-Report-Collection; adversary label: CozyBear (RU APT).
-[6] [BushidoToken Breach Report Collection - SolarWinds breach report (December 2020) via solarwinds.com](https://orangematter.solarwinds.com/2021/01/11/new-findings-from-our-investigation-of-sunburst/)
-   Source index: https://github.com/BushidoUK/Breach-Report-Collection; adversary label: CozyBear (RU APT).
 

--- a/_threat_actors/cold-river.md
+++ b/_threat_actors/cold-river.md
@@ -22,7 +22,10 @@ In short, “Cold River” is a sophisticated threat (actor) that utilizes DNS s
 *No curated IOCs are currently published for this actor. This section will be updated when stable, attributable indicators are available.*
 
 ## Malware and Tools
-*Information pending cataloguing.*
+### Russian APT Tool Matrix observations
+| Category | Observed tools |
+|---|---|
+| OffSec | EvilGinx |
 
 ## Attribution and Evidence
 *Information pending cataloguing.*

--- a/_threat_actors/curly-comrades.md
+++ b/_threat_actors/curly-comrades.md
@@ -29,6 +29,16 @@ Curly COMrades is a threat actor identified by Amazon Threat Intelligence and Bi
 - **ComRAT**
 - **Windows Remote Desktop**
 
+### Russian APT Tool Matrix observations
+| Category | Observed tools |
+|---|---|
+| Credential Theft | Mimikatz, ProcDump, TrickDump |
+| Defense Evasion | Garble |
+| LOLBAS | DCSync, curl |
+| Networking | Resocks, SOCKS5, stunnel |
+| OffSec | Impacket |
+| RMM Tools | RemoteUtilities |
+
 ## Attribution and Evidence
 **Country of Origin**: Russia
 *Additional attribution information pending cataloguing.*

--- a/_threat_actors/sandworm.md
+++ b/_threat_actors/sandworm.md
@@ -43,12 +43,20 @@ This threat actor targets industrial control systems, using a tool called Black 
 - **BlackHole**
 - **PowerRAT**
 
+### Russian APT Tool Matrix observations
+| Category | Observed tools |
+|---|---|
+| Defense Evasion | SDelete, libprocesshider |
+| Exfiltration | Rclone |
+| LOLBAS | BITSAdmin, BITSadmin, certutil, curl |
+| Networking | Chisel, OpenSSH, Pivotnacci, ReGeorg, Tor |
+| OffSec | Cobalt Strike, Empyre, Impacket, JuicyPotatoNG, Metasploit, Meterpreter, PAS Web Shell, PoshC2, PowerShell Empire, RottenPotatoNG, WSO Web Shell, Weevely Web Shell |
+| RMM Tools | Atera, RemCom, Splashtop |
+
 ## Attribution and Evidence
 **Country of Origin**: Russia
 *Additional attribution information pending cataloguing.*
 
 ## References
-
-[1] [BushidoToken Breach Report Collection - Viasat KA-SAT breach report (February 2022) via news.viasat.com](https://news.viasat.com/blog/corporate/ka-sat-network-cyber-attack-overview)
-   Source index: https://github.com/BushidoUK/Breach-Report-Collection; adversary label: Sandworm (RU APT).
+*References pending cataloguing.*
 

--- a/_threat_actors/uta0352.md
+++ b/_threat_actors/uta0352.md
@@ -28,6 +28,11 @@ UTA0352 is a Russian threat actor attributed to phishing campaigns that exploit 
 ## Malware and Tools
 - **Xploit**
 
+### Russian APT Tool Matrix observations
+| Category | Observed tools |
+|---|---|
+| Networking | insiders[.]vscode[.]dev, vscode-redirect[.]azurewebsites.net |
+
 ## Attribution and Evidence
 **Country of Origin**: Russia
 *Additional attribution information pending cataloguing.*

--- a/_threat_actors/void-blizzard.md
+++ b/_threat_actors/void-blizzard.md
@@ -30,6 +30,12 @@ Void Blizzard’s cyberespionage operations tend to be highly targeted at specif
 - **Cyber Eye RAT**
 - **Blizzard**
 
+### Russian APT Tool Matrix observations
+| Category | Observed tools |
+|---|---|
+| Discovery | AzureHound |
+| OffSec | EvilGinx |
+
 ## Attribution and Evidence
 **Country of Origin**: Russia
 *Additional attribution information pending cataloguing.*

--- a/data/imports/russian-apt-tool-matrix/mapping_overrides.yml
+++ b/data/imports/russian-apt-tool-matrix/mapping_overrides.yml
@@ -1,0 +1,43 @@
+# Reviewed mappings for the BushidoUK Russian APT Tool Matrix.
+# Treat this source as a secondary Russian APT tradecraft reference; only enrich existing actors.
+match_overrides:
+  berserkbear:
+    - Dragonfly
+  cozybear:
+    - APT29
+  coldriver:
+    - Cold River
+  curlycomrades:
+    - Curly COMrades
+  emberbear:
+    - Ember Bear
+  fancybear:
+    - APT28
+  forestblizzard:
+    - APT28
+  gamaredon:
+    - Gamaredon Group
+  gamaredongroup:
+    - Gamaredon Group
+  laundrybear:
+    - Void Blizzard
+  sandworm:
+    - Sandworm
+  starblizzard:
+    - Cold River
+  turla:
+    - Turla
+  voidblizzard:
+    - Void Blizzard
+  voidblizzardlaundrybear:
+    - Void Blizzard
+  uta0352uta0355:
+    - UTA0352
+    - UTA0355
+excluded_labels:
+  - UAC-0020
+  - UAC-0050
+  - UAC-0180
+  - UAC-0188
+tool_drop_list:
+  - Unknown

--- a/docs/importers.md
+++ b/docs/importers.md
@@ -141,6 +141,62 @@ The importer preserves source attribution using the pattern:
 
 `Tool observations were reviewed from the BushidoUK Ransomware Tool Matrix (https://github.com/BushidoUK/Ransomware-Tool-Matrix). The matrix is used here as a secondary ransomware tradecraft reference, not as sole attribution evidence.`
 
+## Russian APT Tool Matrix Importer
+
+`scripts/import-russian-apt-tool-matrix.rb` enriches existing Russian APT actors with reviewed tool observations from the BushidoUK Russian APT Tool Matrix.
+
+Source: https://github.com/BushidoUK/Russian-APT-Tool-Matrix
+
+### Why this importer is conservative
+
+- The matrix is a secondary tradecraft reference, not canonical actor identity data.
+- Imports only update existing actors; they do not create new actors.
+- Tools are stored in provenance and rendered as grouped observations on actor pages, not as volatile IOCs.
+- Compound labels and alias collisions require reviewed mappings before import.
+
+Reviewed mappings live in `data/imports/russian-apt-tool-matrix/mapping_overrides.yml`.
+
+### Commands
+
+Fetch a snapshot:
+
+```bash
+ruby scripts/import-russian-apt-tool-matrix.rb fetch --output data/imports/russian-apt-tool-matrix/2026-04-28
+```
+
+Preview reviewed matches:
+
+```bash
+ruby scripts/import-russian-apt-tool-matrix.rb plan --snapshot data/imports/russian-apt-tool-matrix/2026-04-28
+```
+
+Apply the enrichment:
+
+```bash
+ruby scripts/import-russian-apt-tool-matrix.rb import --snapshot data/imports/russian-apt-tool-matrix/2026-04-28
+```
+
+Write a machine-readable review report:
+
+```bash
+ruby scripts/import-russian-apt-tool-matrix.rb plan --snapshot data/imports/russian-apt-tool-matrix/2026-04-28 --report-json tmp/russian-apt-tool-matrix-report.json
+```
+
+### Field mapping
+
+| Matrix Field | Our Schema Field | Notes |
+|--------------|------------------|-------|
+| Tool category tables | `provenance.russian_apt_tool_matrix.tools_by_category` | Stable grouped tool observations by actor |
+| Group profile tool tables | `provenance.russian_apt_tool_matrix.tools_by_category` | Merged with category table observations |
+| Group profile sources / ThreatIntelligence report links | `provenance.russian_apt_tool_matrix.references` | Supporting report links for analyst review |
+| Compound actor labels | `match_overrides` entries | Fan out reviewed references to each existing actor when appropriate |
+
+### Attribution
+
+The importer preserves source attribution using the pattern:
+
+`Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence.`
+
 ## Commands
 
 Fetch a public snapshot:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -213,6 +213,18 @@ ruby scripts/import-ransomware-tool-matrix.rb import --snapshot data/imports/ran
 
 ---
 
+### import-russian-apt-tool-matrix.rb
+
+Import BushidoUK Russian APT Tool Matrix observations for existing actors.
+
+```bash
+ruby scripts/import-russian-apt-tool-matrix.rb fetch --output data/imports/russian-apt-tool-matrix/$(date +%F)
+ruby scripts/import-russian-apt-tool-matrix.rb plan --snapshot data/imports/russian-apt-tool-matrix/DATE
+ruby scripts/import-russian-apt-tool-matrix.rb import --snapshot data/imports/russian-apt-tool-matrix/DATE
+```
+
+---
+
 ### import-aptnotes.rb
 
 Import APTnotes references.

--- a/scripts/generate-pages.rb
+++ b/scripts/generate-pages.rb
@@ -183,19 +183,24 @@ def get_country_flag(country)
   "🏳️"
 end
 
-def ransomware_tool_matrix_tools(actor)
+def tool_matrix_observations(actor)
   provenance = actor['provenance']
   return {} unless provenance.is_a?(Hash)
 
-  matrix = provenance['ransomware_tool_matrix']
-  return {} unless matrix.is_a?(Hash)
+  {
+    'Ransomware Tool Matrix observations' => provenance['ransomware_tool_matrix'],
+    'Russian APT Tool Matrix observations' => provenance['russian_apt_tool_matrix']
+  }.each_with_object({}) do |(label, matrix), memo|
+    next unless matrix.is_a?(Hash)
 
-  tools_by_category = matrix['tools_by_category']
-  return {} unless tools_by_category.is_a?(Hash)
+    tools_by_category = matrix['tools_by_category']
+    next unless tools_by_category.is_a?(Hash)
 
-  tools_by_category.each_with_object({}) do |(category, tools), memo|
-    normalized_tools = Array(tools).map(&:to_s).map(&:strip).reject(&:empty?).uniq
-    memo[category.to_s] = normalized_tools unless normalized_tools.empty?
+    normalized = tools_by_category.each_with_object({}) do |(category, tools), category_memo|
+      normalized_tools = Array(tools).map(&:to_s).map(&:strip).reject(&:empty?).uniq
+      category_memo[category.to_s] = normalized_tools unless normalized_tools.empty?
+    end
+    memo[label] = normalized unless normalized.empty?
   end
 end
 
@@ -314,7 +319,7 @@ def build_body(actor)
   # Malware
   sections << "## Malware and Tools"
   mal_list = actor['malware'] || []
-  matrix_tools = ransomware_tool_matrix_tools(actor)
+  matrix_observations = tool_matrix_observations(actor)
   
   if mal_list && mal_list.any?
     mal_list.each do |m|
@@ -330,14 +335,18 @@ def build_body(actor)
     end
   end
 
-  if matrix_tools.any?
+  if matrix_observations.any?
     sections << "" if mal_list && mal_list.any?
-    sections << "### Ransomware Tool Matrix observations"
-    sections << "| Category | Observed tools |"
-    sections << "|---|---|"
-    matrix_tools.sort.each do |category, tools|
-      sections << "| #{category} | #{tools.sort.join(', ')} |"
+    matrix_observations.sort.each do |label, matrix_tools|
+      sections << "### #{label}"
+      sections << "| Category | Observed tools |"
+      sections << "|---|---|"
+      matrix_tools.sort.each do |category, tools|
+        sections << "| #{category} | #{tools.sort.join(', ')} |"
+      end
+      sections << ""
     end
+    sections.pop if sections.last == ""
   elsif !mal_list || mal_list.empty?
     sections << "*Information pending cataloguing.*"
   end

--- a/scripts/import-automated-sources.rb
+++ b/scripts/import-automated-sources.rb
@@ -72,6 +72,14 @@ SOURCES = [
     snapshot_root: 'data/imports/ransomware-tool-matrix',
     report_name: 'ransomware-tool-matrix-report.json',
     fetch_limit: false
+  ),
+  Source.new(
+    key: 'russian-apt-tool-matrix',
+    label: 'BushidoUK Russian APT Tool Matrix',
+    script: 'scripts/import-russian-apt-tool-matrix.rb',
+    snapshot_root: 'data/imports/russian-apt-tool-matrix',
+    report_name: 'russian-apt-tool-matrix-report.json',
+    fetch_limit: false
   )
 ].freeze
 

--- a/scripts/import-russian-apt-tool-matrix.rb
+++ b/scripts/import-russian-apt-tool-matrix.rb
@@ -1,0 +1,510 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'digest'
+require 'fileutils'
+require 'json'
+require 'net/http'
+require 'optparse'
+require 'set'
+require 'time'
+require 'uri'
+require 'yaml'
+require_relative 'actor_store'
+
+class RussianAptToolMatrixImporter
+  DEFAULT_SNAPSHOT_ROOT = 'data/imports/russian-apt-tool-matrix'.freeze
+  DEFAULT_OVERRIDES_FILE = 'data/imports/russian-apt-tool-matrix/mapping_overrides.yml'.freeze
+  SOURCE_NAME = 'BushidoUK Russian APT Tool Matrix'.freeze
+  SOURCE_REPOSITORY = 'https://github.com/BushidoUK/Russian-APT-Tool-Matrix'.freeze
+  SOURCE_TREE_URL = 'https://api.github.com/repos/BushidoUK/Russian-APT-Tool-Matrix/git/trees/main?recursive=1'.freeze
+  RAW_BASE_URL = 'https://raw.githubusercontent.com/BushidoUK/Russian-APT-Tool-Matrix/main'.freeze
+  SOURCE_ATTRIBUTION = 'Tool observations were reviewed from the BushidoUK Russian APT Tool Matrix (https://github.com/BushidoUK/Russian-APT-Tool-Matrix). The matrix is used here as a secondary Russian APT tradecraft reference, not as sole attribution evidence.'.freeze
+
+  CATEGORY_LABELS = {
+    'RMM-Tools.md' => 'RMM Tools',
+    'Exfiltration.md' => 'Exfiltration',
+    'CredentialTheft.md' => 'Credential Theft',
+    'DefenseEvasion.md' => 'Defense Evasion',
+    'Networking.md' => 'Networking',
+    'Discovery.md' => 'Discovery',
+    'Offsec.md' => 'OffSec',
+    'LOLBAS.md' => 'LOLBAS'
+  }.freeze
+
+  def initialize(argv)
+    @argv = argv.dup
+    @command = @argv.shift
+    @options = {
+      output: nil,
+      snapshot: nil,
+      actor_filters: [],
+      limit: nil,
+      overrides_file: DEFAULT_OVERRIDES_FILE,
+      report_json: nil,
+      write: false
+    }
+    @overrides = {
+      excluded_labels: Set.new,
+      match_overrides: {},
+      tool_drop_list: Set.new
+    }
+  end
+
+  def run
+    case @command
+    when 'fetch'
+      parse_fetch_options
+      fetch_snapshot
+    when 'plan'
+      parse_import_options
+      load_overrides
+      import_snapshot
+    when 'import'
+      parse_import_options
+      @options[:write] = true
+      load_overrides
+      import_snapshot
+    else
+      puts usage
+      exit 1
+    end
+  end
+
+  private
+
+  def usage
+    <<~TEXT
+      Usage:
+        ruby scripts/import-russian-apt-tool-matrix.rb fetch [options]
+        ruby scripts/import-russian-apt-tool-matrix.rb plan --snapshot PATH [options]
+        ruby scripts/import-russian-apt-tool-matrix.rb import --snapshot PATH [options]
+
+      Notes:
+        - Enriches existing actors only; it does not create new actors.
+        - Imports stable tool/category observations and source references into provenance.
+        - Matching overrides should be reviewed before broad imports.
+    TEXT
+  end
+
+  def parse_fetch_options
+    OptionParser.new do |opts|
+      opts.banner = 'Usage: ruby scripts/import-russian-apt-tool-matrix.rb fetch [options]'
+      opts.on('--output DIR', 'Snapshot output directory') { |value| @options[:output] = value }
+    end.parse!(@argv)
+
+    @options[:output] ||= File.join(DEFAULT_SNAPSHOT_ROOT, Time.now.utc.strftime('%Y-%m-%d'))
+  end
+
+  def parse_import_options
+    OptionParser.new do |opts|
+      opts.banner = 'Usage: ruby scripts/import-russian-apt-tool-matrix.rb plan|import --snapshot PATH [options]'
+      opts.on('--snapshot PATH', 'Snapshot directory') { |value| @options[:snapshot] = value }
+      opts.on('--actor NAME', 'Restrict to a specific actor (repeatable)') { |value| @options[:actor_filters] << value }
+      opts.on('--limit N', Integer, 'Process only the first N matched actors') { |value| @options[:limit] = value }
+      opts.on('--overrides PATH', 'Override mapping file') { |value| @options[:overrides_file] = value }
+      opts.on('--report-json PATH', 'Write a machine-readable report') { |value| @options[:report_json] = value }
+    end.parse!(@argv)
+
+    return if @options[:snapshot]
+
+    warn 'A snapshot path is required for plan/import.'
+    exit 1
+  end
+
+  def fetch_snapshot
+    FileUtils.mkdir_p(@options[:output])
+    tree = JSON.parse(http_get(URI.parse(SOURCE_TREE_URL)))
+    paths = tree.fetch('tree', []).map { |entry| entry['path'] }.select { |path| snapshot_file?(path) }.sort
+    checksums = {}
+
+    paths.each do |path|
+      body = http_get(URI.parse("#{RAW_BASE_URL}/#{path}"))
+      local_path = File.join(@options[:output], path)
+      FileUtils.mkdir_p(File.dirname(local_path))
+      File.write(local_path, body)
+      checksums[path] = Digest::SHA256.hexdigest(body)
+    end
+
+    manifest = {
+      'source_name' => SOURCE_NAME,
+      'source_repository' => SOURCE_REPOSITORY,
+      'source_url' => SOURCE_TREE_URL,
+      'raw_base_url' => RAW_BASE_URL,
+      'retrieved_at' => Time.now.utc.iso8601,
+      'file_count' => paths.length,
+      'checksums_sha256' => checksums
+    }
+    File.write(File.join(@options[:output], 'manifest.yml'), YAML.dump(manifest))
+    puts "Fetched #{paths.length} Russian APT Tool Matrix files into #{@options[:output]}"
+  rescue JSON::ParserError => e
+    warn "Invalid GitHub tree response: #{e.message}"
+    exit 1
+  end
+
+  def snapshot_file?(path)
+    path == 'README.md' ||
+      path.start_with?('Tools/') ||
+      path.start_with?('GroupProfiles/') ||
+      path.start_with?('Other/')
+  end
+
+  def import_snapshot
+    records, manifest = load_snapshot
+    actors = ActorStore.load_all
+    actor_index, actors_by_name = build_actor_index(actors)
+    candidates, evaluated = build_candidates(records, actor_index, actors_by_name)
+    candidates.select! { |candidate| actor_filter_match?(candidate[:actor_name]) } unless @options[:actor_filters].empty?
+    candidates = candidates.first(@options[:limit]) if @options[:limit]
+
+    report = build_report(evaluated, candidates, manifest)
+    File.write(@options[:report_json], JSON.pretty_generate(report) + "\n") if @options[:report_json]
+    print_report(report)
+    return unless @options[:write]
+
+    apply_candidates(candidates, actors, manifest)
+    puts "Applied Russian APT Tool Matrix enrichments to #{candidates.length} actors"
+  end
+
+  def load_snapshot
+    manifest_path = File.join(@options[:snapshot], 'manifest.yml')
+    manifest = File.exist?(manifest_path) ? safe_load_yaml_file(manifest_path) : {}
+    records = Hash.new { |hash, key| hash[key] = empty_record(key) }
+
+    load_tool_tables(records)
+    load_group_profiles(records)
+    load_threat_intel(records)
+
+    [records.values.reject { |record| @overrides[:excluded_labels].include?(record[:label_key]) }, manifest]
+  end
+
+  def empty_record(label)
+    normalized = normalize_matrix_label(label)
+    {
+      label: normalized[:label],
+      label_key: normalized[:key],
+      roles: Set.new,
+      tools_by_category: Hash.new { |hash, key| hash[key] = Set.new },
+      source_files: Set.new,
+      references: {},
+      community_reports: []
+    }
+  end
+
+  def load_tool_tables(records)
+    CATEGORY_LABELS.each do |filename, category|
+      path = File.join(@options[:snapshot], 'Tools', filename)
+      next unless File.exist?(path)
+
+      parse_markdown_table(File.read(path)).each do |row|
+        tool = sanitize_text(row['Tool Name'])
+        next if tool.empty?
+
+        split_actor_labels(row['Threat Group Usage']).each do |label|
+          record = records[label]
+          record[:tools_by_category][category] << tool
+          record[:source_files] << "Tools/#{filename}"
+        end
+      end
+    end
+  end
+
+  def load_group_profiles(records)
+    Dir.glob(File.join(@options[:snapshot], 'GroupProfiles', '*.md')).sort.each do |path|
+      relative_path = relative_snapshot_path(path)
+      body = File.read(path)
+      label = group_profile_label(path, body)
+      record = records[label]
+      record[:source_files] << relative_path
+
+      parse_markdown_table(body).each do |row|
+        CATEGORY_LABELS.values.each do |category|
+          split_tool_cell(row[category]).each { |tool| record[:tools_by_category][category] << tool }
+        end
+
+        report = row['Report']
+        date = sanitize_text(row['Date Published'])
+        next if report.to_s.empty?
+
+        extract_links(report).each do |link|
+          record[:references][link[:url]] ||= {
+            title: link[:title],
+            url: link[:url],
+            date: date,
+            source_file: relative_path
+          }
+        end
+      end
+    end
+  end
+
+  def load_threat_intel(records)
+    Dir.glob(File.join(@options[:snapshot], 'Other', 'ThreatIntelligence.md')).sort.each do |path|
+      relative_path = relative_snapshot_path(path)
+      parse_markdown_table(File.read(path)).each do |row|
+        label = row['Russian APT'] || row['Threat Group'] || row['Group']
+        next if label.to_s.strip.empty?
+
+        record = records[label]
+        record[:source_files] << relative_path
+        report = row['#StopRansomware Report'] || row['Report'] || row['Source']
+        extract_links(report).each do |link|
+          record[:references][link[:url]] ||= {
+            title: link[:title],
+            url: link[:url],
+            date: sanitize_text(row['Date Published']),
+            source_file: relative_path
+          }
+        end
+      end
+    end
+  end
+
+  def build_candidates(records, actor_index, actors_by_name)
+    evaluated = records.flat_map do |record|
+      next if record[:tools_by_category].empty? && record[:references].empty? && record[:community_reports].empty?
+
+      override_match = @overrides[:match_overrides].key?(record[:label_key])
+      matches = @overrides[:match_overrides][record[:label_key]] || actor_index[record[:label_key]].to_a
+      matches = matches.select { |name| actors_by_name.key?(name) }.uniq
+      if override_match && matches.length > 1
+        matches.map { |name| record.merge(action: 'update', matched_actor_names: [name]) }
+      else
+        action = if matches.empty?
+                   'unmatched'
+                 elsif matches.length == 1
+                   'update'
+                 else
+                   'review'
+                 end
+        [record.merge(action: action, matched_actor_names: matches)]
+      end
+    end.compact
+
+    updates = evaluated.select { |candidate| candidate[:action] == 'update' }
+    merged = updates.group_by { |candidate| candidate[:matched_actor_names].first }.map do |actor_name, actor_records|
+      merge_actor_records(actor_name, actor_records)
+    end
+
+    [merged.sort_by { |candidate| candidate[:actor_name].downcase }, evaluated]
+  end
+
+  def merge_actor_records(actor_name, records)
+    merged = empty_record(records.first[:label])
+    merged[:source_labels] = records.map { |record| record[:label] }.uniq.sort
+    merged[:label] = merged[:source_labels].join(' / ')
+    merged[:label_key] = normalize_key(merged[:label])
+    merged[:records] = records
+    records.each do |record|
+      record[:roles].each { |role| merged[:roles] << role }
+      record[:source_files].each { |source_file| merged[:source_files] << source_file }
+      record[:community_reports].each { |community_report| merged[:community_reports] << community_report }
+      record[:references].each { |url, reference| merged[:references][url] ||= reference }
+      record[:tools_by_category].each do |category, tools|
+        tools.each { |tool| merged[:tools_by_category][category] << tool }
+      end
+    end
+    merged.merge(action: 'update', actor_name: actor_name, matched_actor_names: [actor_name], records: records)
+  end
+
+  def apply_candidates(candidates, actors, manifest)
+    actors_by_name = actors.each_with_object({}) { |actor, memo| memo[actor['name']] = actor }
+    candidates.each do |candidate|
+      actor = actors_by_name[candidate[:actor_name]]
+      next unless actor
+
+      actor['provenance'] = {} unless actor['provenance'].is_a?(Hash)
+      actor['provenance']['russian_apt_tool_matrix'] = provenance_payload(candidate, manifest)
+      actor['last_updated'] = Time.now.utc.strftime('%Y-%m-%d')
+      path = File.join(ActorStore::ACTORS_DIR, "#{ActorStore.slug_for(actor['url'])}.yml")
+      File.write(path, ActorStore.serialize_actor(actor))
+    end
+  end
+
+  def provenance_payload(candidate, manifest)
+    {
+      'source_repository' => SOURCE_REPOSITORY,
+      'source_dataset_url' => SOURCE_TREE_URL,
+      'source_attribution' => SOURCE_ATTRIBUTION,
+      'source_retrieved_at' => manifest['retrieved_at'] || Time.now.utc.iso8601,
+      'source_label' => candidate[:label],
+      'actor_roles' => candidate[:roles].to_a.sort,
+      'source_files' => candidate[:source_files].to_a.sort,
+      'tools_by_category' => candidate[:tools_by_category].transform_values { |tools| tools.to_a.sort }.sort.to_h,
+      'references' => candidate[:references].values.sort_by { |ref| [ref[:date].to_s, ref[:title].to_s] }.map do |ref|
+        {
+          'title' => ref[:title],
+          'url' => ref[:url],
+          'date' => ref[:date],
+          'source_file' => ref[:source_file]
+        }.reject { |_key, value| value.to_s.empty? }
+      end,
+      'community_reports' => candidate[:community_reports].uniq
+    }.reject { |_key, value| value.respond_to?(:empty?) && value.empty? }
+  end
+
+  def build_actor_index(actors)
+    index = Hash.new { |hash, key| hash[key] = Set.new }
+    by_name = {}
+    actors.each do |actor|
+      name = actor['name'].to_s
+      by_name[name] = actor
+      ([name] + Array(actor['aliases'])).compact.each do |label|
+        key = normalize_key(label)
+        next if key.empty?
+
+        index[key] << name
+      end
+    end
+    [index, by_name]
+  end
+
+  def build_report(records, candidates, manifest)
+    updated_label_keys = candidates.flat_map { |candidate| candidate[:records].map { |record| record[:label_key] } }.to_set
+    unmatched = records.reject { |record| updated_label_keys.include?(record[:label_key]) }
+
+    {
+      timestamp: Time.now.utc.iso8601,
+      source: SOURCE_NAME,
+      repository: SOURCE_REPOSITORY,
+      retrieved_at: manifest['retrieved_at'],
+      source_records: records.length,
+      actors_with_updates: candidates.length,
+      actor_updates: candidates.map do |candidate|
+        {
+          name: candidate[:actor_name],
+          source_labels: candidate[:source_labels],
+          tool_count: candidate[:tools_by_category].values.sum(&:length),
+          categories: candidate[:tools_by_category].keys.sort,
+          reference_count: candidate[:references].length,
+          community_report_count: candidate[:community_reports].length
+        }
+      end,
+      unmatched_labels: unmatched.map { |record| record[:label] }.sort
+    }
+  end
+
+  def print_report(report)
+    puts "\n=== Russian APT Tool Matrix Import Plan ==="
+    puts "Source records: #{report[:source_records]}"
+    puts "Actors with updates: #{report[:actors_with_updates]}"
+    report[:actor_updates].each do |entry|
+      puts "\nUPDATE: #{entry[:name]} (#{entry[:source_labels].join(', ')})"
+      puts "  Tools: #{entry[:tool_count]} across #{entry[:categories].join(', ')}"
+      puts "  References: #{entry[:reference_count]}"
+      puts "  Community reports: #{entry[:community_report_count]}"
+    end
+    puts "\nUnmatched labels: #{report[:unmatched_labels].length}"
+    puts "\n=== Run with import to apply ===" unless @options[:write]
+  end
+
+  def parse_markdown_table(body)
+    tables = []
+    lines = body.each_line.map(&:chomp)
+    lines.each_with_index do |line, index|
+      next unless line.start_with?('|')
+      next unless lines[index + 1].to_s.match?(/\A\|?\s*:?-{3,}/)
+
+      headers = split_markdown_row(line)
+      cursor = index + 2
+      while cursor < lines.length && lines[cursor].start_with?('|')
+        values = split_markdown_row(lines[cursor])
+        tables << headers.each_with_index.to_h { |header, offset| [sanitize_text(header), sanitize_text(values[offset])] }
+        cursor += 1
+      end
+    end
+    tables
+  end
+
+  def split_markdown_row(line)
+    line.strip.sub(/\A\|/, '').sub(/\|\z/, '').split('|').map(&:strip)
+  end
+
+  def split_actor_labels(value)
+    sanitize_text(value).split(/\s*,\s*/).map(&:strip).reject(&:empty?)
+  end
+
+  def split_tool_cell(value)
+    sanitize_text(value).split(%r{\s*<br\s*/?>\s*}i).map(&:strip).reject do |tool|
+      tool.empty? || @overrides[:tool_drop_list].include?(normalize_key(tool))
+    end
+  end
+
+  def group_profile_label(path, body)
+    title = body[/^#\s+(.+?)(?:'s)? Tools\s*$/, 1]
+    title ||= File.basename(path, '.md')
+    title.gsub(/([a-z])([A-Z])/, '\1 \2').tr('_', ' ')
+  end
+
+  def extract_links(value)
+    text = value.to_s
+    links = text.scan(/\[([^\]]+)\]\(([^)]+)\)/).map do |title, url|
+      { title: sanitize_text(title), url: sanitize_link(url) }
+    end
+    bare_urls = text.scan(%r{https?://[^\s)<|]+}).map { |url| { title: host_title(url), url: sanitize_link(url) } }
+    (links + bare_urls).uniq { |link| link[:url] }.reject { |link| link[:url].empty? }
+  end
+
+  def normalize_matrix_label(label)
+    text = sanitize_text(label)
+    clean = text.gsub(/\([^)]*\)/, '').strip
+    { label: clean, key: normalize_key(clean), roles: Set.new }
+  end
+
+  def actor_filter_match?(actor_name)
+    @options[:actor_filters].any? { |filter| normalize_key(filter) == normalize_key(actor_name) }
+  end
+
+  def load_overrides
+    return unless File.exist?(@options[:overrides_file])
+
+    payload = safe_load_yaml_file(@options[:overrides_file]) || {}
+    @overrides[:excluded_labels] = Array(payload['excluded_labels']).map { |value| normalize_key(value) }.to_set
+    @overrides[:tool_drop_list] = Array(payload['tool_drop_list']).map { |value| normalize_key(value) }.to_set
+    @overrides[:match_overrides] = (payload['match_overrides'] || {}).each_with_object({}) do |(key, value), memo|
+      memo[normalize_key(key)] = Array(value).map(&:to_s)
+    end
+  end
+
+  def http_get(uri, limit = 5)
+    raise "Too many redirects for #{uri}" if limit <= 0
+
+    response = Net::HTTP.get_response(uri)
+    case response
+    when Net::HTTPSuccess
+      response.body
+    when Net::HTTPRedirection
+      http_get(URI.parse(response['location']), limit - 1)
+    else
+      raise "HTTP #{response.code} for #{uri}"
+    end
+  end
+
+  def safe_load_yaml_file(path)
+    YAML.safe_load(File.read(path), permitted_classes: [], aliases: true)
+  end
+
+  def relative_snapshot_path(path)
+    path.sub(%r{\A#{Regexp.escape(@options[:snapshot])}/?}, '')
+  end
+
+  def normalize_key(value)
+    sanitize_text(value).downcase.gsub(/[^a-z0-9]+/, '')
+  end
+
+  def sanitize_text(value)
+    value.to_s.gsub(/\s+/, ' ').strip
+  end
+
+  def sanitize_link(value)
+    value.to_s.strip
+  end
+
+  def host_title(url)
+    URI.parse(url).host || url
+  rescue URI::InvalidURIError
+    url
+  end
+end
+
+RussianAptToolMatrixImporter.new(ARGV).run if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a snapshot-backed importer for the BushidoUK Russian APT Tool Matrix and applies reviewed enrichment to existing Russian APT-related profiles. The importer fetches upstream repository content, parses tool/category observations, group profiles, and threat intelligence references, then stores results under `provenance.russian_apt_tool_matrix` without creating new actors.

## Related Issue

Follow-up requested regular import path for https://github.com/BushidoUK/Russian-APT-Tool-Matrix.

## Type of Change

- [ ] Bug fix (non-breaking change)
- [ ] New threat actor (non-breaking change)
- [x] Documentation update
- [x] Code quality improvement

## Testing

- [x] `ruby scripts/import-russian-apt-tool-matrix.rb plan --snapshot data/imports/russian-apt-tool-matrix/2026-04-28 --report-json tmp/russian-apt-tool-matrix-plan.json`
- [x] `ruby scripts/import-russian-apt-tool-matrix.rb import --snapshot data/imports/russian-apt-tool-matrix/2026-04-28 --report-json tmp/russian-apt-tool-matrix-import.json`
- [x] `ruby scripts/validate-content.rb`
- [x] `bundle exec jekyll build --safe`
- [x] `bash scripts/validate.sh`

## Checklists

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have commented my code where necessary
- [x] I have updated the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass

## Source Attribution

For threat actor data changes, confirm source licensing:
- [ ] Data is CC0 licensed
- [ ] Data is CC BY 4.0 licensed
- [ ] I have permission to use this data
- [x] Data is from a public source with attribution

Attribution is stored in each updated actor under `provenance.russian_apt_tool_matrix.source_attribution`; reviewed mapping overrides are tracked while fetched snapshots remain ignored as operational cache.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c23327e0-ab71-4dc0-b1c4-5d325c1e3cef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c23327e0-ab71-4dc0-b1c4-5d325c1e3cef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

