### PR TITLE
Add filtering options to attack tactics page

### DIFF
--- a/attack-tactics.html
+++ b/attack-tactics.html
@@ -27,6 +27,13 @@ permalink: /attack-tactics/
         <label for="tactic-hub-search">Filter:</label>
         <input type="text" id="tactic-hub-search" placeholder="TAxxxx or tactic name..." autocomplete="off">
       </div>
+      <div class="filter-group">
+        <label for="tactic-hub-scope">Show:</label>
+        <select id="tactic-hub-scope">
+          <option value="linked" selected>Only tactics with linked threat actors</option>
+          <option value="all">All tactics</option>
+        </select>
+      </div>
       <button type="button" id="tactic-hub-apply">Search</button>
       <button type="button" id="tactic-hub-clear" class="secondary">Clear</button>
     </div>
@@ -80,20 +87,29 @@ permalink: /attack-tactics/
 
     function filterList() {
       var term = document.getElementById('tactic-hub-search').value.trim().toLowerCase();
+      var scope = document.getElementById('tactic-hub-scope').value;
       var filtered = tactics.filter(function (t) {
+        var id = (t.mitre_id || '');
+        var actorCount = (byTactic[id] || []).length;
+        if (scope === 'linked' && actorCount === 0) return false;
+
         if (!term) return true;
-        var id = (t.mitre_id || '').toLowerCase();
+        var idLc = id.toLowerCase();
         var title = (t.title || '').toLowerCase();
-        return id.includes(term) || title.includes(term);
+        return idLc.includes(term) || title.includes(term);
       });
       render(filtered);
     }
 
+    filterList();
+
     document.getElementById('tactic-hub-apply').onclick = filterList;
     document.getElementById('tactic-hub-clear').onclick = function () {
       document.getElementById('tactic-hub-search').value = '';
-      render(tactics);
+      document.getElementById('tactic-hub-scope').value = 'linked';
+      filterList();
     };
+    document.getElementById('tactic-hub-scope').addEventListener('change', filterList);
     document.getElementById('tactic-hub-search').addEventListener('keypress', function (e) {
       if (e.key === 'Enter') filterList();
     });


### PR DESCRIPTION
- Introduced a new dropdown to filter tactics by linked threat actors or all tactics.
- Updated the filtering logic to accommodate the new scope selection.
- Ensured the search functionality resets to the default filter when cleared.

## Description

## Related Issue

## Type of Change

- [ ] Bug fix (non-breaking change)
- [ ] New threat actor (non-breaking change)
- [ ] Documentation update
- [ ] Code quality improvement

## Testing

## Checklists

- [ ] My code follows the style guidelines
- [ ] I have performed a self-review
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix works
- [ ] New and existing tests pass

## Source Attribution

For threat actor data changes, confirm source licensing:
- [ ] Data is CC0 licensed
- [ ] Data is CC BY 4.0 licensed
- [ ] I have permission to use this data
- [ ] Data is from a public source with attribution