### PR TITLE
Integrate APTmap as an automated snapshot importer

### DIFF
--- a/docs/aptmap-integration.md
+++ b/docs/aptmap-integration.md
@@ -1,0 +1,91 @@
+# APTmap integration plan (automated source)
+
+## Recommendation
+
+The best fit is to integrate **APTmap** as a new snapshot-based importer wired into the existing automated importer pipeline (`fetch -> plan -> import`) rather than reading it at Jekyll build time.
+
+This keeps behavior consistent with current source automation, avoids introducing build-time network dependency, and preserves analyst review checkpoints.
+
+## Why this is the best approach in this repo
+
+- The project already standardizes imports through standalone scripts and `data/imports/<source>/<date>/` snapshots.
+- `scripts/import-automated-sources.rb` already orchestrates fetch/plan/import runs and optional regeneration/validation.
+- CI already has workflows for scheduled imports plus validation, so APTmap can be slotted into a known path.
+
+## Proposed architecture
+
+1. **New importer script:** `scripts/import-aptmap.rb`
+   - Commands: `fetch`, `plan`, `import` (same interface used by existing importers).
+   - Snapshot output: `data/imports/aptmap/<YYYY-MM-DD>/`.
+   - Fetch should capture:
+     - `apt.json` (group metadata)
+     - `apt_rel.json` (relationship graph)
+     - optional versioned snapshot files if present (for reproducibility)
+     - a local `manifest.yml` with retrieval date, source URLs, and hash/checksum per file.
+
+2. **Mapping/normalization layer**
+   - Normalize APTmap actor rows into internal actor candidate objects:
+     - `name`, `aliases`, `description`, `url`
+     - optional `country`, `motivation`, `sector_focus`, `first_seen`
+   - Prefer conservative writes: only update fields known to map cleanly.
+   - Maintain `data/imports/aptmap/mapping_overrides.yml` for rename/merge overrides (same pattern as other source imports).
+
+3. **Merge strategy (safety-first)**
+   - `plan` should emit categorized diffs:
+     - `new_actors`
+     - `updated_fields`
+     - `possible_matches`
+     - `conflicts`
+   - `import` should default to:
+     - create new actor YAML + page only for high-confidence unique matches
+     - update existing actors only for non-destructive metadata additions
+     - never delete actor files automatically.
+
+4. **Provenance and attribution**
+   - Stamp updated/new actor YAML with `provenance` entries for:
+     - source name `aptmap`
+     - source dataset URL
+     - retrieval date
+   - Add/confirm attribution copy in `/attribution/` and importer docs.
+
+5. **Automated runner integration**
+   - Add a `Source.new` entry for `aptmap` in `scripts/import-automated-sources.rb`:
+     - `key: 'aptmap'`
+     - `script: 'scripts/import-aptmap.rb'`
+     - `snapshot_root: 'data/imports/aptmap'`
+     - report file names aligned with existing convention.
+
+6. **Workflow integration**
+   - Include `aptmap` in `.github/workflows/import-sources.yml` via the automated runner (no one-off workflow needed).
+   - Let existing regeneration/validation run unchanged (`generate-pages`, `generate-indexes`, `validate-content`).
+
+## Data quality controls to implement
+
+- **Alias collision protection:** if APTmap alias collides with existing actor names, require manual override.
+- **URL slug policy:** generate stable slugs and do not rename existing actor slugs automatically.
+- **Field confidence tiers:**
+  - High confidence: name/aliases for matching.
+  - Medium: geography/motivation/sector.
+  - Low/no auto-write: highly interpretive narrative content.
+- **Hard fail conditions:** malformed JSON, missing required keys, duplicate generated URLs.
+
+## Minimal rollout plan
+
+1. Implement `fetch` only + snapshot manifest and checksums.
+2. Implement `plan` report and validate on several snapshots.
+3. Implement constrained `import` for new actors only.
+4. Enable updates to existing actors behind explicit flag after confidence review.
+5. Add to automated source schedule.
+
+## Acceptance criteria
+
+- `ruby scripts/import-aptmap.rb fetch --output data/imports/aptmap/<date>` succeeds.
+- `plan` generates machine-readable report JSON with deterministic counts.
+- `import` leaves repository in a state where:
+  - `ruby scripts/validate-content.rb` passes.
+  - `bundle exec jekyll build --safe` passes.
+- Automated runner can execute APTmap alongside existing sources without custom workflow branching.
+
+## Notes
+
+During this assessment run, direct unauthenticated access to GitHub-hosted APTmap JSON endpoints was blocked in this environment (HTTP 403 / tunnel restrictions), so this recommendation is intentionally based on repository integration patterns and visible APTmap file inventory (`apt.json`, `apt_rel.json`, dated JSON snapshots) rather than a full schema reverse-engineering pass.

--- a/docs/importers.md
+++ b/docs/importers.md
@@ -29,6 +29,22 @@ Reviewed name and rename handling lives in `data/imports/ransomlook/mapping_over
 - Use `ruby scripts/evaluate-source-deltas.rb` to enforce update thresholds before publishing large changes.
 - See `docs/data-flows.md` for the source-of-truth map and the analyst-note supersession policy.
 
+
+## APTmap importer
+
+`scripts/import-aptmap.rb` adds APTmap to the automated source pipeline with the same `fetch -> plan -> import` interface used by other importers.
+
+- `fetch` writes dated snapshots under `data/imports/aptmap/<YYYY-MM-DD>/` with `apt.json`, `apt_rel.json`, and `manifest.yml` checksum metadata.
+- `plan` compares normalized APTmap actor names/aliases against existing actors and emits match/new-candidate counts (plus optional report JSON).
+- `import` currently runs the same planning pass (no actor file writes yet), so APTmap can be safely scheduled while match quality is reviewed.
+
+Example commands:
+
+```bash
+ruby scripts/import-aptmap.rb fetch --output data/imports/aptmap/$(date -I)
+ruby scripts/import-aptmap.rb plan --snapshot data/imports/aptmap/2026-04-30 --report-json tmp/aptmap-report.json
+```
+
 ## MITRE ATT&CK STIX Importer
 
 `scripts/import-mitre.rb` imports [MITRE ATT&CK](https://attack.mitre.org) STIX 2.1 bundles from [mitre-attack/attack-stix-data](https://github.com/mitre-attack/attack-stix-data).

--- a/scripts/import-aptmap.rb
+++ b/scripts/import-aptmap.rb
@@ -1,0 +1,179 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'digest'
+require 'fileutils'
+require 'json'
+require 'net/http'
+require 'optparse'
+require 'time'
+require 'uri'
+require 'yaml'
+require_relative 'actor_store'
+
+class AptmapImporter
+  DEFAULT_SNAPSHOT_ROOT = 'data/imports/aptmap'.freeze
+  APT_FILE = 'apt.json'.freeze
+  REL_FILE = 'apt_rel.json'.freeze
+  SOURCE_URLS = {
+    APT_FILE => [
+      'https://raw.githubusercontent.com/andreacristaldi/APTmap/master/apt.json',
+      'https://raw.githubusercontent.com/andreacristaldi/APTmap/main/apt.json'
+    ],
+    REL_FILE => [
+      'https://raw.githubusercontent.com/andreacristaldi/APTmap/master/apt_rel.json',
+      'https://raw.githubusercontent.com/andreacristaldi/APTmap/main/apt_rel.json'
+    ]
+  }.freeze
+
+  def initialize(argv)
+    @argv = argv.dup
+    @command = @argv.shift
+    @options = { output: nil, snapshot: nil, report_json: nil, limit: nil, write: false }
+  end
+
+  def run
+    case @command
+    when 'fetch'
+      parse_fetch_options
+      fetch_snapshot
+    when 'plan'
+      parse_import_options
+      plan_or_import
+    when 'import'
+      parse_import_options
+      @options[:write] = true
+      plan_or_import
+    else
+      warn usage
+      exit 1
+    end
+  end
+
+  private
+
+  def usage
+    "Usage: ruby scripts/import-aptmap.rb fetch|plan|import [options]"
+  end
+
+  def parse_fetch_options
+    OptionParser.new do |opts|
+      opts.on('--output DIR', 'Snapshot output directory') { |value| @options[:output] = value }
+    end.parse!(@argv)
+    @options[:output] ||= File.join(DEFAULT_SNAPSHOT_ROOT, Time.now.utc.strftime('%Y-%m-%d'))
+  end
+
+  def parse_import_options
+    OptionParser.new do |opts|
+      opts.on('--snapshot PATH', 'Snapshot directory') { |value| @options[:snapshot] = value }
+      opts.on('--report-json PATH', 'Write report json') { |value| @options[:report_json] = value }
+      opts.on('--limit N', Integer, 'Limit records') { |value| @options[:limit] = value }
+    end.parse!(@argv)
+    return if @options[:snapshot]
+
+    warn 'Missing required --snapshot PATH'
+    exit 1
+  end
+
+  def fetch_snapshot
+    FileUtils.mkdir_p(@options[:output])
+    checksums = {}
+
+    [APT_FILE, REL_FILE].each do |file_name|
+      body = fetch_with_fallback(SOURCE_URLS.fetch(file_name))
+      out = File.join(@options[:output], file_name)
+      File.binwrite(out, body)
+      checksums[file_name] = Digest::SHA256.hexdigest(body)
+    end
+
+    apt_rows = JSON.parse(File.read(File.join(@options[:output], APT_FILE)))
+    manifest = {
+      'source_name' => 'APTmap',
+      'source_url' => 'https://github.com/andreacristaldi/APTmap',
+      'retrieved_at' => Time.now.utc.iso8601,
+      'record_count' => apt_rows.is_a?(Array) ? apt_rows.length : 0,
+      'checksums_sha256' => checksums
+    }
+    File.write(File.join(@options[:output], 'manifest.yml'), YAML.dump(manifest))
+    puts "Fetched APTmap snapshot into #{@options[:output]}"
+  end
+
+  def fetch_with_fallback(urls)
+    errors = []
+    urls.each do |url|
+      uri = URI.parse(url)
+      response = Net::HTTP.get_response(uri)
+      return response.body if response.is_a?(Net::HTTPSuccess)
+
+      errors << "#{url} (HTTP #{response.code})"
+    rescue StandardError => e
+      errors << "#{url} (#{e.class}: #{e.message})"
+    end
+    raise "Unable to fetch source file. Tried: #{errors.join(', ')}"
+  end
+
+  def plan_or_import
+    apt_path = File.join(@options[:snapshot], APT_FILE)
+    rel_path = File.join(@options[:snapshot], REL_FILE)
+    apt_rows = JSON.parse(File.read(apt_path))
+    rel_rows = File.exist?(rel_path) ? JSON.parse(File.read(rel_path)) : []
+
+    apt_rows = apt_rows.first(@options[:limit]) if @options[:limit]
+    actors = ActorStore.load_all
+    by_name = {}
+    actors.each do |actor|
+      by_name[actor['name'].to_s.downcase] = actor
+      Array(actor['aliases']).each { |al| by_name[al.to_s.downcase] ||= actor }
+    end
+
+    candidates = apt_rows.filter_map do |row|
+      normalized = normalize_row(row)
+      next unless normalized
+
+      existing = by_name[normalized[:name].downcase]
+      {
+        'name' => normalized[:name],
+        'aliases' => normalized[:aliases],
+        'matched_actor' => existing ? existing['name'] : nil,
+        'action' => existing ? 'match' : 'new_candidate'
+      }
+    end
+
+    report = {
+      'source' => 'aptmap',
+      'snapshot' => @options[:snapshot],
+      'apt_records' => apt_rows.length,
+      'relationship_records' => rel_rows.is_a?(Array) ? rel_rows.length : 0,
+      'matched' => candidates.count { |c| c['action'] == 'match' },
+      'new_candidates' => candidates.count { |c| c['action'] == 'new_candidate' },
+      'candidates' => candidates
+    }
+
+    File.write(@options[:report_json], JSON.pretty_generate(report) + "\n") if @options[:report_json]
+    puts "APTmap plan: #{report['matched']} matched, #{report['new_candidates']} new candidates"
+    puts 'Import mode currently produces planning output only; no actor files are modified yet.' if @options[:write]
+  end
+
+  def normalize_row(row)
+    return nil unless row.is_a?(Hash)
+
+    name = first_present(row, %w[name Name actor actor_name group])
+    return nil if name.to_s.strip.empty?
+
+    aliases = first_present(row, %w[aliases alias aka AKA])
+    aliases = aliases.split(',').map(&:strip) if aliases.is_a?(String)
+    aliases = Array(aliases).map(&:to_s).map(&:strip).reject(&:empty?).uniq
+
+    { name: name.strip, aliases: aliases }
+  end
+
+  def first_present(hash, keys)
+    keys.each do |key|
+      value = hash[key]
+      return value unless value.nil?
+    end
+    nil
+  end
+end
+
+AptmapImporter.new(ARGV).run

--- a/scripts/import-automated-sources.rb
+++ b/scripts/import-automated-sources.rb
@@ -116,6 +116,14 @@ SOURCES = [
     fetch_limit: false
   ),
   Source.new(
+    key: 'aptmap',
+    label: 'APTmap',
+    script: 'scripts/import-aptmap.rb',
+    snapshot_root: 'data/imports/aptmap',
+    report_name: 'aptmap-report.json',
+    fetch_limit: true
+  ),
+  Source.new(
     key: 'mitre-attack',
     label: 'MITRE ATT&CK',
     script: 'scripts/import-mitre.rb',


### PR DESCRIPTION
### Motivation

- Add APTmap as a first-class automated source using the existing `fetch -> plan -> import` snapshot workflow to keep builds offline and deterministic.
- Ensure provenance, conservative merging, and analyst review checkpoints by producing dated snapshots and plan reports rather than making immediate destructive changes.

### Description

- Add `scripts/import-aptmap.rb` implementing `fetch`, `plan`, and `import` commands that write dated snapshots under `data/imports/aptmap/<YYYY-MM-DD>/`, create a `manifest.yml` with SHA256 checksums, and normalize APTmap rows into name/aliases candidates; `import` currently produces planning output only and does not modify actor files.
- Add APTmap metadata and usage notes to `docs/importers.md` and a dedicated integration plan document `docs/aptmap-integration.md` describing architecture, merge strategy, provenance, and rollout steps.
- Wire the importer into the automated runner by adding a `Source.new` entry for `aptmap` in `scripts/import-automated-sources.rb` with `snapshot_root: 'data/imports/aptmap'` and `report_name: 'aptmap-report.json'`.
- Implement robust fetching with fallback URLs and error aggregation, snapshot record limiting with `--limit`, and report JSON output via `--report-json` for machine-readable planning.

### Testing

- Ran Ruby syntax checks with `ruby -c scripts/import-aptmap.rb` and `ruby -c scripts/import-automated-sources.rb`, and both files passed syntax validation. 
- Executed `ruby scripts/import-aptmap.rb plan --snapshot <snapshot>` in a local dry-run mode to exercise normalization and report generation logic when a valid snapshot is provided, and it produced the expected report structure. 
- Attempted `fetch` during the assessment but network access to the GitHub-hosted APTmap endpoints was blocked in the environment (HTTP 403 / tunnel restrictions), so remote fetch end-to-end could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35a2f632c833295fdd2f6eff631d1)