### PR TITLE
Fix APTmap importer GeoJSON normalization, report output, and docs

### DIFF
--- a/docs/aptmap-integration.md
+++ b/docs/aptmap-integration.md
@@ -1,10 +1,6 @@
-# APTmap integration plan (automated source)
+# APTmap integration status (automated source)
 
-## Recommendation
-
-The best fit is to integrate **APTmap** as a new snapshot-based importer wired into the existing automated importer pipeline (`fetch -> plan -> import`) rather than reading it at Jekyll build time.
-
-This keeps behavior consistent with current source automation, avoids introducing build-time network dependency, and preserves analyst review checkpoints.
+APTmap is integrated as a snapshot-based importer in the automated source pipeline (`fetch -> plan -> import`) rather than at Jekyll build time.
 
 ## Why this is the best approach in this repo
 
@@ -12,15 +8,14 @@ This keeps behavior consistent with current source automation, avoids introducin
 - `scripts/import-automated-sources.rb` already orchestrates fetch/plan/import runs and optional regeneration/validation.
 - CI already has workflows for scheduled imports plus validation, so APTmap can be slotted into a known path.
 
-## Proposed architecture
+## Current implementation
 
-1. **New importer script:** `scripts/import-aptmap.rb`
+1. **Importer script:** `scripts/import-aptmap.rb`
    - Commands: `fetch`, `plan`, `import` (same interface used by existing importers).
    - Snapshot output: `data/imports/aptmap/<YYYY-MM-DD>/`.
-   - Fetch should capture:
+   - `fetch` captures:
      - `apt.json` (group metadata)
      - `apt_rel.json` (relationship graph)
-     - optional versioned snapshot files if present (for reproducibility)
      - a local `manifest.yml` with retrieval date, source URLs, and hash/checksum per file.
 
 2. **Mapping/normalization layer**
@@ -49,7 +44,7 @@ This keeps behavior consistent with current source automation, avoids introducin
    - Add/confirm attribution copy in `/attribution/` and importer docs.
 
 5. **Automated runner integration**
-   - Add a `Source.new` entry for `aptmap` in `scripts/import-automated-sources.rb`:
+   - `scripts/import-automated-sources.rb` includes a `Source.new` entry for `aptmap`:
      - `key: 'aptmap'`
      - `script: 'scripts/import-aptmap.rb'`
      - `snapshot_root: 'data/imports/aptmap'`
@@ -69,13 +64,10 @@ This keeps behavior consistent with current source automation, avoids introducin
   - Low/no auto-write: highly interpretive narrative content.
 - **Hard fail conditions:** malformed JSON, missing required keys, duplicate generated URLs.
 
-## Minimal rollout plan
+## Operational notes
 
-1. Implement `fetch` only + snapshot manifest and checksums.
-2. Implement `plan` report and validate on several snapshots.
-3. Implement constrained `import` for new actors only.
-4. Enable updates to existing actors behind explicit flag after confidence review.
-5. Add to automated source schedule.
+- `import` currently performs the same planning pass as `plan` (no actor file writes yet), which keeps APTmap safe to run on schedule while matching quality is reviewed.
+- `--report-json` now creates parent directories automatically, so paths like `tmp/aptmap-report.json` work without pre-creating `tmp/`.
 
 ## Acceptance criteria
 
@@ -86,6 +78,12 @@ This keeps behavior consistent with current source automation, avoids introducin
   - `bundle exec jekyll build --safe` passes.
 - Automated runner can execute APTmap alongside existing sources without custom workflow branching.
 
-## Notes
+## Verification snapshot
 
-During this assessment run, direct unauthenticated access to GitHub-hosted APTmap JSON endpoints was blocked in this environment (HTTP 403 / tunnel restrictions), so this recommendation is intentionally based on repository integration patterns and visible APTmap file inventory (`apt.json`, `apt_rel.json`, dated JSON snapshots) rather than a full schema reverse-engineering pass.
+The importer was verified against a live snapshot at `data/imports/aptmap/2026-04-30` using:
+
+```bash
+ruby scripts/import-aptmap.rb fetch --output data/imports/aptmap/2026-04-30
+ruby scripts/import-aptmap.rb plan --snapshot data/imports/aptmap/2026-04-30 --report-json tmp/aptmap-report.json
+ruby scripts/import-aptmap.rb import --snapshot data/imports/aptmap/2026-04-30 --report-json tmp/aptmap-import-report.json
+```

--- a/scripts/import-aptmap.rb
+++ b/scripts/import-aptmap.rb
@@ -115,7 +115,7 @@ class AptmapImporter
   def plan_or_import
     apt_path = File.join(@options[:snapshot], APT_FILE)
     rel_path = File.join(@options[:snapshot], REL_FILE)
-    apt_rows = JSON.parse(File.read(apt_path))
+    apt_rows = normalize_apt_rows(JSON.parse(File.read(apt_path)))
     rel_rows = File.exist?(rel_path) ? JSON.parse(File.read(rel_path)) : []
 
     apt_rows = apt_rows.first(@options[:limit]) if @options[:limit]
@@ -149,9 +149,15 @@ class AptmapImporter
       'candidates' => candidates
     }
 
-    File.write(@options[:report_json], JSON.pretty_generate(report) + "\n") if @options[:report_json]
+    write_report_json(report) if @options[:report_json]
     puts "APTmap plan: #{report['matched']} matched, #{report['new_candidates']} new candidates"
     puts 'Import mode currently produces planning output only; no actor files are modified yet.' if @options[:write]
+  end
+
+  def write_report_json(report)
+    report_path = @options[:report_json]
+    FileUtils.mkdir_p(File.dirname(report_path))
+    File.write(report_path, JSON.pretty_generate(report) + "\n")
   end
 
   def normalize_row(row)
@@ -160,11 +166,18 @@ class AptmapImporter
     name = first_present(row, %w[name Name actor actor_name group])
     return nil if name.to_s.strip.empty?
 
-    aliases = first_present(row, %w[aliases alias aka AKA])
+    aliases = first_present(row, %w[aliases alias aka AKA other-names other_names])
     aliases = aliases.split(',').map(&:strip) if aliases.is_a?(String)
     aliases = Array(aliases).map(&:to_s).map(&:strip).reject(&:empty?).uniq
 
     { name: name.strip, aliases: aliases }
+  end
+
+  def normalize_apt_rows(payload)
+    return payload if payload.is_a?(Array)
+    return payload.fetch('features', []).map { |feature| feature['properties'] } if payload.is_a?(Hash) && payload['features'].is_a?(Array)
+
+    []
   end
 
   def first_present(hash, keys)


### PR DESCRIPTION
### Motivation
- APTmap snapshots are GeoJSON-style objects (`features[].properties`) and the importer assumed a top-level array, causing `plan`/`import` to produce empty results and fail to use `other-names` for alias matching. 
- `--report-json` failed when the target directory did not exist, which broke automated runner usage and ad-hoc verification commands.

### Description
- Normalize APTmap payloads with `normalize_apt_rows` so `features[].properties` are mapped into the importer before matching. 
- Expand alias extraction to include `other-names`/`other_names` so APTmap alternate names are considered during matching. 
- Make `--report-json` safe by creating parent directories via `FileUtils.mkdir_p` before writing reports (`write_report_json`). 
- Update `docs/aptmap-integration.md` from a proposal to an implementation status doc and add a concrete verification snapshot and operational notes; keep `import` planning-only by default.

### Testing
- Ran `ruby scripts/import-aptmap.rb fetch --output data/imports/aptmap/2026-04-30` which completed successfully. 
- Ran `ruby scripts/import-aptmap.rb plan --snapshot data/imports/aptmap/2026-04-30 --report-json tmp/aptmap-report.json` and `ruby scripts/import-aptmap.rb import --snapshot data/imports/aptmap/2026-04-30 --report-json tmp/aptmap-import-report.json`, which produced meaningful output (`APTmap plan: 813 matched, 3 new candidates`) and completed without error. 
- Ran `ruby -c scripts/import-aptmap.rb` and `ruby scripts/import-automated-sources.rb --source aptmap --no-fetch --plan-only --date 2026-04-30` for end-to-end automation checks, and all commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f365b199048332ae6db2fd4e94719e)