### PR TITLE
Add RedDrip7 APT_Digital_Weapon importer and attach RedDrip7 provenance for APT28

### DIFF
--- a/_data/actors/apt28.yml
+++ b/_data/actors/apt28.yml
@@ -112,6 +112,13 @@ provenance:
     source_dataset_url: "https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master/enterprise-attack/enterprise-attack.json"
     source_record_id: "G0007"
     source_retrieved_at: "2026-04-26T07:05:44Z"
+  reddrip7_apt_digital_weapon:
+    actor_folder: "APT28"
+    actor_readme_url: "https://raw.githubusercontent.com/RedDrip7/APT_Digital_Weapon/master/APT28/README.md"
+    ioc_hashes_url: "https://raw.githubusercontent.com/RedDrip7/APT_Digital_Weapon/master/APT28/APT28_hash.md"
+    source_attribution: "Indicators of compromise were reviewed from RedDrip7/APT_Digital_Weapon and are treated as secondary, community-curated leads requiring independent verification before operational use."
+    source_dataset_url: "https://github.com/RedDrip7/APT_Digital_Weapon"
+    source_retrieved_at: "2026-04-30T00:00:00Z"
   russian_apt_tool_matrix:
     references:
       - title: "media.defense.gov"

--- a/_threat_actors/apt28.md
+++ b/_threat_actors/apt28.md
@@ -37,7 +37,7 @@ APT28 is a threat group that has been attributed to Russia's General Staff Main 
 *Information pending cataloguing.*
 
 ## Notable Indicators of Compromise (IOCs)
-*No atomic indicators are listed in this profile. The APTnotes snapshot indexes 26 public reports that may contain IOCs; see Source Attribution for dataset links.*
+*No atomic indicators are listed directly in this profile. Additional community-curated IOC hashes are available in RedDrip7/APT_Digital_Weapon (APT28 folder), and should be independently validated before defensive or investigative use.*
 
 ## Malware and Tools
 - **CyberGate**
@@ -134,4 +134,5 @@ APT28 is a threat group that has been attributed to Russia's General Staff Main 
 [13] [Symantec APT28 Oct 2018](https://www.symantec.com/blogs/election-security/apt28-espionage-military-government)
 [14] [ESET Zebrocy May 2019](https://www.welivesecurity.com/2019/05/22/journey-zebrocy-land/)
 [15] [US District Court Indictment GRU Oct 2018](https://www.justice.gov/opa/page/file/1098481/download)
+[16] [RedDrip7 APT_Digital_Weapon (APT28)](https://github.com/RedDrip7/APT_Digital_Weapon/tree/master/APT28)
 

--- a/docs/importers.md
+++ b/docs/importers.md
@@ -30,6 +30,26 @@ Reviewed name and rename handling lives in `data/imports/ransomlook/mapping_over
 - See `docs/data-flows.md` for the source-of-truth map and the analyst-note supersession policy.
 
 
+
+## RedDrip7 APT_Digital_Weapon importer
+
+`scripts/import-reddrip7-apt-digital-weapon.rb` adds RedDrip7 IOC-hash metadata as a **secondary** provenance source for existing actors.
+
+- `fetch` snapshots upstream folder metadata into `data/imports/reddrip7-apt-digital-weapon/<YYYY-MM-DD>/`.
+- `plan` matches actor names/aliases against folder names and reports how many existing actors can be enriched.
+- `import` writes/updates `provenance.reddrip7_apt_digital_weapon` on matched `_data/actors/*.yml` records.
+
+Example commands:
+
+```bash
+ruby scripts/import-reddrip7-apt-digital-weapon.rb fetch --output data/imports/reddrip7-apt-digital-weapon/$(date -I)
+ruby scripts/import-reddrip7-apt-digital-weapon.rb plan --snapshot data/imports/reddrip7-apt-digital-weapon/2026-04-30 --report-json tmp/reddrip7-report.json
+```
+
+Attribution pattern:
+
+`Indicators of compromise were reviewed from RedDrip7/APT_Digital_Weapon and are treated as secondary, community-curated leads requiring independent verification before operational use.`
+
 ## APTmap importer
 
 `scripts/import-aptmap.rb` adds APTmap to the automated source pipeline with the same `fetch -> plan -> import` interface used by other importers.

--- a/scripts/import-automated-sources.rb
+++ b/scripts/import-automated-sources.rb
@@ -124,6 +124,14 @@ SOURCES = [
     fetch_limit: false
   ),
   Source.new(
+    key: 'reddrip7-apt-digital-weapon',
+    label: 'RedDrip7 APT_Digital_Weapon',
+    script: 'scripts/import-reddrip7-apt-digital-weapon.rb',
+    snapshot_root: 'data/imports/reddrip7-apt-digital-weapon',
+    report_name: 'reddrip7-apt-digital-weapon-report.json',
+    fetch_limit: false
+  ),
+  Source.new(
     key: 'aptmap',
     label: 'APTmap',
     script: 'scripts/import-aptmap.rb',

--- a/scripts/import-reddrip7-apt-digital-weapon.rb
+++ b/scripts/import-reddrip7-apt-digital-weapon.rb
@@ -1,0 +1,163 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'digest'
+require 'fileutils'
+require 'json'
+require 'net/http'
+require 'optparse'
+require 'time'
+require 'yaml'
+require_relative 'actor_store'
+
+class RedDrip7AptDigitalWeaponImporter
+  DEFAULT_API_ROOT = 'https://api.github.com/repos/RedDrip7/APT_Digital_Weapon'.freeze
+  DEFAULT_SNAPSHOT_ROOT = 'data/imports/reddrip7-apt-digital-weapon'.freeze
+  SOURCE_DATASET_URL = 'https://github.com/RedDrip7/APT_Digital_Weapon'.freeze
+  SOURCE_ATTRIBUTION = 'Indicators of compromise were reviewed from RedDrip7/APT_Digital_Weapon and are treated as secondary, community-curated leads requiring independent verification before operational use.'.freeze
+
+  def initialize(argv)
+    @argv = argv.dup
+    @command = @argv.shift
+    @options = { api_root: DEFAULT_API_ROOT, output: nil, snapshot: nil, report_json: nil, write: false }
+  end
+
+  def run
+    case @command
+    when 'fetch'
+      parse_fetch_options
+      fetch
+    when 'plan'
+      parse_plan_options
+      process_snapshot(false)
+    when 'import'
+      parse_plan_options
+      process_snapshot(true)
+    else
+      warn usage
+      exit 1
+    end
+  end
+
+  private
+
+  def usage
+    "Usage: ruby scripts/import-reddrip7-apt-digital-weapon.rb fetch|plan|import [options]"
+  end
+
+  def parse_fetch_options
+    OptionParser.new do |opts|
+      opts.on('--api-root URL') { |v| @options[:api_root] = v }
+      opts.on('--output DIR') { |v| @options[:output] = v }
+    end.parse!(@argv)
+    @options[:output] ||= File.join(DEFAULT_SNAPSHOT_ROOT, Time.now.utc.strftime('%Y-%m-%d'))
+  end
+
+  def parse_plan_options
+    OptionParser.new do |opts|
+      opts.on('--snapshot PATH') { |v| @options[:snapshot] = v }
+      opts.on('--report-json PATH') { |v| @options[:report_json] = v }
+    end.parse!(@argv)
+    abort 'A snapshot path is required.' unless @options[:snapshot]
+  end
+
+  def fetch
+    FileUtils.mkdir_p(@options[:output])
+    items = http_get_json("#{@options[:api_root]}/contents/")
+    directories = Array(items).select { |row| row['type'] == 'dir' }
+    records = directories.map do |row|
+      folder = row['name']
+      {
+        'folder' => folder,
+        'folder_key' => normalize(folder),
+        'actor_readme_url' => "https://raw.githubusercontent.com/RedDrip7/APT_Digital_Weapon/master/#{escape_folder(folder)}/README.md",
+        'ioc_hashes_url' => "https://raw.githubusercontent.com/RedDrip7/APT_Digital_Weapon/master/#{escape_folder(folder)}/#{escape_folder(folder)}_hash.md"
+      }
+    end
+
+    manifest = {
+      'source_name' => 'RedDrip7 APT_Digital_Weapon',
+      'source_dataset_url' => SOURCE_DATASET_URL,
+      'source_api_root' => @options[:api_root],
+      'retrieved_at' => Time.now.utc.iso8601,
+      'record_count' => records.length,
+      'source_checksum_sha256' => Digest::SHA256.hexdigest(JSON.generate(records)),
+      'folders_file' => 'folders.json'
+    }
+
+    File.write(File.join(@options[:output], 'folders.json'), JSON.pretty_generate(records) + "\n")
+    File.write(File.join(@options[:output], 'manifest.yml'), YAML.dump(manifest))
+    puts "Fetched #{records.length} folders into #{@options[:output]}"
+  end
+
+  def process_snapshot(write)
+    snapshot_file = File.directory?(@options[:snapshot]) ? File.join(@options[:snapshot], 'folders.json') : @options[:snapshot]
+    folders = JSON.parse(File.read(snapshot_file))
+    folder_by_key = folders.each_with_object({}) { |f, memo| memo[f['folder_key']] = f }
+
+    actors = ActorStore.load_all
+    matches = []
+    unmatched = []
+
+    actors.each do |actor|
+      aliases = Array(actor['aliases']).map(&:to_s)
+      candidates = ([actor['name'].to_s] + aliases).map { |x| normalize(x) }
+      record = candidates.map { |key| folder_by_key[key] }.compact.first
+      if record
+        matches << [actor, record]
+      else
+        unmatched << actor['name']
+      end
+    end
+
+    updates = 0
+    if write
+      matches.each do |actor, record|
+        actor['provenance'] ||= {}
+        actor['provenance']['reddrip7_apt_digital_weapon'] = {
+          'actor_folder' => record['folder'],
+          'actor_readme_url' => record['actor_readme_url'],
+          'ioc_hashes_url' => record['ioc_hashes_url'],
+          'source_attribution' => SOURCE_ATTRIBUTION,
+          'source_dataset_url' => SOURCE_DATASET_URL,
+          'source_retrieved_at' => Time.now.utc.iso8601
+        }
+        ActorStore.save_actor(actor)
+        updates += 1
+      end
+    end
+
+    report = {
+      'source' => 'reddrip7-apt-digital-weapon',
+      'snapshot' => @options[:snapshot],
+      'matched_actors' => matches.length,
+      'unmatched_actors' => unmatched.length,
+      'write' => write,
+      'updated_actors' => updates,
+      'sample_matches' => matches.first(25).map { |actor, record| { 'actor' => actor['name'], 'folder' => record['folder'] } }
+    }
+
+    File.write(@options[:report_json], JSON.pretty_generate(report) + "\n") if @options[:report_json]
+    puts "Matched #{matches.length} actors#{write ? "; updated #{updates}" : ''}."
+  end
+
+  def http_get_json(url)
+    uri = URI(url)
+    req = Net::HTTP::Get.new(uri)
+    req['User-Agent'] = 'ThreatActor.info importer'
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') { |http| http.request(req) }
+    raise "HTTP #{res.code} for #{url}" unless res.is_a?(Net::HTTPSuccess)
+
+    JSON.parse(res.body)
+  end
+
+  def normalize(value)
+    value.to_s.downcase.gsub(/[^a-z0-9]/, '')
+  end
+
+  def escape_folder(value)
+    value.to_s.gsub(' ', '%20')
+  end
+end
+
+RedDrip7AptDigitalWeaponImporter.new(ARGV).run


### PR DESCRIPTION
### Motivation
- Add community-curated IOC metadata from the RedDrip7/APT_Digital_Weapon repository as a secondary provenance source for existing actor profiles. 
- Make the new importer available in the automated importer registry and document its workflow so snapshots can be fetched/planned/imported like other sources.

### Description
- New importer `scripts/import-reddrip7-apt-digital-weapon.rb` that can `fetch`, `plan`, and `import` folder-based snapshots from the RedDrip7 repo and writes snapshot manifests to `data/imports/reddrip7-apt-digital-weapon/<YYYY-MM-DD>/`.
- Wire the importer into the automation registry by adding a `reddrip7-apt-digital-weapon` Source entry in `scripts/import-automated-sources.rb`.
- Document the importer and its usage and attribution text in `docs/importers.md` under a new "RedDrip7 APT_Digital_Weapon importer" section with example commands.
- Enrich the APT28 actor records with a `provenance.reddrip7_apt_digital_weapon` block in `_data/actors/apt28.yml` and add a reference to the RedDrip7 folder in `_threat_actors/apt28.md` to surface the community IOC guidance while stating it requires independent verification.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d32d95ec8332b626eae1bb469f72)