### PR TITLE
Include missing importers in automated source runner

### DIFF
--- a/scripts/import-automated-sources.rb
+++ b/scripts/import-automated-sources.rb
@@ -124,11 +124,27 @@ SOURCES = [
     fetch_limit: false
   ),
   Source.new(
+    key: 'bushido-breach-reports',
+    label: 'BushidoToken Breach Reports',
+    script: 'scripts/import-bushido-breach-reports.rb',
+    snapshot_root: 'data/imports/bushido-breach-reports',
+    report_name: 'bushido-breach-reports-report.json',
+    fetch_limit: false
+  ),
+  Source.new(
     key: 'reddrip7-apt-digital-weapon',
     label: 'RedDrip7 APT_Digital_Weapon',
     script: 'scripts/import-reddrip7-apt-digital-weapon.rb',
     snapshot_root: 'data/imports/reddrip7-apt-digital-weapon',
     report_name: 'reddrip7-apt-digital-weapon-report.json',
+    fetch_limit: false
+  ),
+  Source.new(
+    key: 'eternal-liberty',
+    label: 'EternalLiberty',
+    script: 'scripts/import-eternal-liberty.rb',
+    snapshot_root: 'data/imports/eternal-liberty',
+    report_name: 'eternal-liberty-report.json',
     fetch_limit: false
   ),
   Source.new(


### PR DESCRIPTION
### Motivation
- The centralized importer orchestration omitted two existing importer scripts, so those sources were not participating in the repo's `fetch → plan → import` automation. 
- When importers are not run via the single runner, downstream Markdown regeneration and index updates (`generate-pages.rb` / `generate-indexes.rb`) can be missed for actor updates from those sources.

### Description
- Added `bushido-breach-reports` as a `Source` entry in `scripts/import-automated-sources.rb` pointing to `scripts/import-bushido-breach-reports.rb` with its snapshot and report paths. 
- Added `eternal-liberty` as a `Source` entry in `scripts/import-automated-sources.rb` pointing to `scripts/import-eternal-liberty.rb` with its snapshot and report paths. 
- These entries ensure both importers participate in the centralized `ruby scripts/import-automated-sources.rb` orchestration and therefore flow into the existing regeneration step that runs `ruby scripts/generate-pages.rb --force`, `ruby scripts/generate-indexes.rb`, and `ruby scripts/validate-content.rb` after an `--apply`.

### Testing
- Ran `ruby -c scripts/import-automated-sources.rb` to verify syntax, which succeeded. 
- Ran `ruby scripts/import-automated-sources.rb --list-sources` to verify the new `bushido-breach-reports` and `eternal-liberty` entries appear, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d7c3401483329fe3fff4eb719376)