### PR TITLE
Add Google Cloud APT Groups importer and ETDA importer enhancements

### DIFF
--- a/docs/importers.md
+++ b/docs/importers.md
@@ -25,6 +25,7 @@ Reviewed name and rename handling lives in `data/imports/ransomlook/mapping_over
 - Run public, machine-consumable source imports through `ruby scripts/import-automated-sources.rb`; analyst notes are intentionally excluded from this runner.
 - Regenerate pages with `ruby scripts/generate-pages.rb --force` after source updates.
 - Regenerate APIs with `ruby scripts/generate-indexes.rb` in the same run.
+- For enrichment sources that include description text (for example ETDA/ThaiCERT and Google Cloud APT Groups), imports append an attributed `### Source: <name>` subsection instead of replacing curated lead descriptions.
 - Prefer **structured IOCs** under **`iocs:`** in `_data/actors/*.yml` (plus legacy top-level IOC lists where applicable); [`scripts/ioc_yaml_reader.rb`](../scripts/ioc_yaml_reader.rb) merges them for **`generate-indexes.rb`** and **`generate-pages.rb`** so `/api/iocs.json` and actor **`ioc_count`** stay aligned with YAML without duplicating Markdown-only pipelines.
 - Use `ruby scripts/evaluate-source-deltas.rb` to enforce update thresholds before publishing large changes.
 - See `docs/data-flows.md` for the source-of-truth map and the analyst-note supersession policy.
@@ -63,6 +64,21 @@ Example commands:
 ```bash
 ruby scripts/import-aptmap.rb fetch --output data/imports/aptmap/$(date -I)
 ruby scripts/import-aptmap.rb plan --snapshot data/imports/aptmap/2026-04-30 --report-json tmp/aptmap-report.json
+```
+
+## Google Cloud APT Groups importer
+
+`scripts/import-google-cloud-apt-groups.rb` adds the Google Cloud Security Insights APT index as a lightweight alias/provenance crosswalk source.
+
+- `fetch` snapshots the source page and writes normalized rows to `data/imports/google-cloud-apt-groups/<YYYY-MM-DD>/`.
+- `plan` reports how many rows match existing actors.
+- `import` applies alias additions, merges source descriptions into actor YAML `description` as a Markdown subheading block (`### Source: Google Cloud APT Groups`) when not already present, and records `provenance.google_cloud_apt_groups` on matched actors.
+
+Example commands:
+
+```bash
+ruby scripts/import-google-cloud-apt-groups.rb fetch --output data/imports/google-cloud-apt-groups/$(date -I)
+ruby scripts/import-google-cloud-apt-groups.rb plan --snapshot data/imports/google-cloud-apt-groups/2026-04-30 --report-json tmp/google-cloud-apt-groups-report.json
 ```
 
 
@@ -982,6 +998,8 @@ Imported provenance fields include:
 ## ETDA / ThaiCERT Threat Group Cards Importer
 
 `scripts/import-etda-thaicert.rb` adds ETDA/ThaiCERT Threat Group Cards as a reviewed threat-group enrichment source.
+
+- `fetch` attempts all configured ETDA inputs (`getcard.cgi?g=all&o=j`, `getcard.cgi?t=all&o=j`, `getmisp.cgi?o=g`, `aptgroups.cgi`, then mirror fallback) and merges overlapping records so aliases/descriptions/metadata from each feed are consolidated in one snapshot.
 
 Source: https://apt.etda.or.th/
 

--- a/scripts/import-automated-sources.rb
+++ b/scripts/import-automated-sources.rb
@@ -124,11 +124,27 @@ SOURCES = [
     fetch_limit: false
   ),
   Source.new(
+    key: 'bushido-breach-reports',
+    label: 'BushidoToken Breach Reports',
+    script: 'scripts/import-bushido-breach-reports.rb',
+    snapshot_root: 'data/imports/bushido-breach-reports',
+    report_name: 'bushido-breach-reports-report.json',
+    fetch_limit: false
+  ),
+  Source.new(
     key: 'reddrip7-apt-digital-weapon',
     label: 'RedDrip7 APT_Digital_Weapon',
     script: 'scripts/import-reddrip7-apt-digital-weapon.rb',
     snapshot_root: 'data/imports/reddrip7-apt-digital-weapon',
     report_name: 'reddrip7-apt-digital-weapon-report.json',
+    fetch_limit: false
+  ),
+  Source.new(
+    key: 'eternal-liberty',
+    label: 'EternalLiberty',
+    script: 'scripts/import-eternal-liberty.rb',
+    snapshot_root: 'data/imports/eternal-liberty',
+    report_name: 'eternal-liberty-report.json',
     fetch_limit: false
   ),
   Source.new(
@@ -138,6 +154,14 @@ SOURCES = [
     snapshot_root: 'data/imports/aptmap',
     report_name: 'aptmap-report.json',
     fetch_limit: true
+  ),
+  Source.new(
+    key: 'google-cloud-apt-groups',
+    label: 'Google Cloud APT Groups',
+    script: 'scripts/import-google-cloud-apt-groups.rb',
+    snapshot_root: 'data/imports/google-cloud-apt-groups',
+    report_name: 'google-cloud-apt-groups-report.json',
+    fetch_limit: false
   ),
   Source.new(
     key: 'mitre-attack',

--- a/scripts/import-etda-thaicert.rb
+++ b/scripts/import-etda-thaicert.rb
@@ -20,6 +20,9 @@ class EtdaThaicertImporter
   DEFAULT_OVERRIDES_FILE = 'data/imports/etda-thaicert/mapping_overrides.yml'.freeze
   SOURCE_NAME = 'ETDA / ThaiCERT Threat Group Cards'.freeze
   SOURCE_URL = 'https://apt.etda.or.th/cgi-bin/getmisp.cgi?o=g'.freeze
+  SOURCE_CARDS_JSON_URL = 'https://apt.etda.or.th/cgi-bin/getcard.cgi?g=all&o=j'.freeze
+  SOURCE_TOOLS_JSON_URL = 'https://apt.etda.or.th/cgi-bin/getcard.cgi?t=all&o=j'.freeze
+  SOURCE_GROUPS_URL = 'https://apt.etda.or.th/cgi-bin/aptgroups.cgi'.freeze
   SOURCE_MIRROR_URL = 'https://huggingface.co/datasets/threatactor-info/etda-thaicert-threat-groups/raw/main/groups.json'.freeze
   SOURCE_REPOSITORY = 'https://apt.etda.or.th/'.freeze
   MANUAL_SOURCE_NAMES = ['Manual Entry', 'Analyst Notes'].freeze
@@ -41,6 +44,9 @@ class EtdaThaicertImporter
     @command = @argv.shift
     @options = {
       source_url: SOURCE_URL,
+      source_cards_json_url: SOURCE_CARDS_JSON_URL,
+      source_tools_json_url: SOURCE_TOOLS_JSON_URL,
+      source_groups_url: SOURCE_GROUPS_URL,
       mirror_url: SOURCE_MIRROR_URL,
       output: nil,
       snapshot: nil,
@@ -102,6 +108,9 @@ class EtdaThaicertImporter
     parser = OptionParser.new do |opts|
       opts.banner = 'Usage: ruby scripts/import-etda-thaicert.rb fetch [options]'
       opts.on('--source-url URL', 'Primary ETDA dataset URL') { |value| @options[:source_url] = value }
+      opts.on('--source-cards-json-url URL', 'ETDA full card JSON URL') { |value| @options[:source_cards_json_url] = value }
+      opts.on('--source-tools-json-url URL', 'ETDA full tooling JSON URL') { |value| @options[:source_tools_json_url] = value }
+      opts.on('--source-groups-url URL', 'ETDA aptgroups HTML URL') { |value| @options[:source_groups_url] = value }
       opts.on('--mirror-url URL', 'Mirror dataset URL (fallback)') { |value| @options[:mirror_url] = value }
       opts.on('--output DIR', 'Snapshot output directory') { |value| @options[:output] = value }
       opts.on('--limit N', Integer, 'Fetch only the first N records after normalization') { |value| @options[:limit] = value }
@@ -131,8 +140,10 @@ class EtdaThaicertImporter
 
   def fetch_snapshot
     FileUtils.mkdir_p(@options[:output])
-    payload, used_url = fetch_source_payload
-    records = normalize_source_payload(payload)
+    payloads, used_urls = fetch_source_payloads
+    group_payloads, tool_payloads = payloads.partition { |entry| entry[:source_url] != @options[:source_tools_json_url] }
+    records = merge_normalized_records(group_payloads.flat_map { |entry| normalize_source_payload(entry[:payload]) })
+    records = merge_tool_observations(records, tool_payloads.flat_map { |entry| extract_tool_records(entry[:payload]) })
     records = records.first(@options[:limit]) if @options[:limit]
 
     groups_path = File.join(@options[:output], 'groups.json')
@@ -142,7 +153,7 @@ class EtdaThaicertImporter
     File.write(manifest_path, YAML.dump({
                                          'source_name' => SOURCE_NAME,
                                          'source_repository' => SOURCE_REPOSITORY,
-                                         'source_url' => used_url,
+                                         'source_url' => used_urls,
                                          'retrieved_at' => Time.now.utc.iso8601,
                                          'record_count' => records.length,
                                          'source_checksum_sha256' => Digest::SHA256.hexdigest(JSON.generate(records)),
@@ -152,16 +163,20 @@ class EtdaThaicertImporter
     puts "Fetched #{records.length} ETDA/ThaiCERT records into #{@options[:output]}"
   end
 
-  def fetch_source_payload
-    [@options[:source_url], @options[:mirror_url]].uniq.each do |url|
+  def fetch_source_payloads
+    sources = [@options[:source_cards_json_url], @options[:source_tools_json_url], @options[:source_url], @options[:source_groups_url], @options[:mirror_url]].uniq
+    payloads = []
+    sources.each do |url|
       next if sanitize_text(url).empty?
 
       payload = http_get(url)
-      return [payload, url]
+      payloads << { payload: payload, source_url: url }
     rescue StandardError => e
       warn "Fetch failed for #{url}: #{e.message}"
     end
-    raise 'Failed to fetch ETDA dataset from source and mirror.'
+    raise 'Failed to fetch ETDA dataset from source(s) and mirror.' if payloads.empty?
+
+    [payloads, payloads.map { |entry| entry[:source_url] }]
   end
 
   def import_snapshot
@@ -320,7 +335,8 @@ class EtdaThaicertImporter
     end
 
     if @options[:force]
-      updates['description'] = record[:description] if !record[:description].to_s.empty? && record[:description] != existing_actor['description']
+      merged_description = merge_description_with_source(existing_actor['description'], record[:description], SOURCE_NAME, record[:source_record_url])
+      updates['description'] = merged_description if !merged_description.nil? && merged_description != existing_actor['description']
       updates['name'] = record[:display_name] if !record[:display_name].to_s.empty? && record[:display_name] != existing_actor['name']
     end
 
@@ -373,6 +389,20 @@ class EtdaThaicertImporter
     return true if current_year.to_s.empty?
 
     candidate_year.to_i > current_year.to_i
+  end
+
+  def merge_description_with_source(current_description, incoming_description, source_label, source_url)
+    incoming = incoming_description.to_s.strip
+    return nil if incoming.empty?
+
+    current = current_description.to_s.strip
+    return incoming if current.empty?
+
+    heading = "### Source: #{source_label}"
+    return nil if current.include?(heading)
+
+    section = [heading, incoming, source_url.to_s.strip.empty? ? SOURCE_URL : source_url.to_s.strip].join("\n")
+    [current, section].join("\n\n")
   end
 
   def build_provenance(record)
@@ -463,7 +493,8 @@ class EtdaThaicertImporter
     updates['source_attribution'] = SOURCE_ATTRIBUTION
 
     # Import fields that were empty in manual entry
-    updates['description'] = record[:description] if !record[:description].to_s.empty? && existing_actor['description'].to_s.empty?
+    merged_description = merge_description_with_source(existing_actor['description'], record[:description], SOURCE_NAME, record[:source_record_url])
+    updates['description'] = merged_description if !merged_description.nil? && merged_description != existing_actor['description']
     updates['country'] = record[:country] if !record[:country].to_s.empty? && existing_actor['country'].to_s.empty?
     updates['name'] = record[:display_name] if !record[:display_name].to_s.empty? && record[:display_name] != existing_actor['name']
 
@@ -595,6 +626,10 @@ class EtdaThaicertImporter
   end
 
   def normalize_source_payload(payload)
+    if payload.is_a?(String) && payload.lstrip.start_with?('<')
+      return normalize_html_groups_payload(payload)
+    end
+
     records = if payload.is_a?(Array)
                 payload
               elsif payload.is_a?(Hash)
@@ -604,6 +639,107 @@ class EtdaThaicertImporter
                 []
               end
     Array(records).filter_map { |record| normalize_record(record) }
+  end
+
+  def normalize_html_groups_payload(html)
+    rows = html.scan(%r{<tr[^>]*>(.*?)</tr>}im).map(&:first)
+    rows.filter_map do |row|
+      cells = row.scan(%r{<t[dh][^>]*>(.*?)</t[dh]>}im).map { |cell| sanitize_text(strip_html(cell.first)) }
+      next if cells.empty?
+      name = cells[0].to_s
+      next if name.empty? || name.casecmp('group').zero?
+      {
+        'name' => name,
+        'description' => cells[2].to_s,
+        'country' => cells[3].to_s,
+        'aliases' => cells[1].to_s.split(/[,;|]/).map(&:strip).reject(&:empty?),
+        'reference' => first_href(row)
+      }
+    end
+  end
+
+  def merge_normalized_records(records)
+    by_key = {}
+    records.each do |record|
+      key = record[:canonical_key]
+      if by_key[key]
+        by_key[key] = merge_record_data(by_key[key], record)
+      else
+        by_key[key] = record
+      end
+    end
+    by_key.values
+  end
+
+  def extract_tool_records(payload)
+    records = if payload.is_a?(Array)
+                payload
+              elsif payload.is_a?(Hash)
+                payload['values'] || payload['data'] || payload['tools'] || payload.values.find { |v| v.is_a?(Array) } || []
+              else
+                []
+              end
+    Array(records).filter_map do |record|
+      next unless record.is_a?(Hash)
+
+      tool_name = sanitize_text(first_non_empty(record['name'], record['tool'], record['title'], record['value']))
+      next if tool_name.empty?
+
+      related = normalize_string_array(first_non_empty(record['groups'], record['actors'], record['threat_groups'], record.dig('meta', 'groups')))
+      related += extract_ids(record, /APT\s?\d{1,3}|G\d{4}/i)
+      { tool_name: tool_name, related_groups: related.uniq }
+    end
+  end
+
+  def merge_tool_observations(records, tool_records)
+    return records if tool_records.empty?
+
+    index = records.each_with_object({}) do |record, memo|
+      memo[record[:canonical_key]] = record
+      memo[normalize_key(record[:display_name])] = record
+      record[:aliases].each { |alias_name| memo[normalize_key(alias_name)] = record }
+    end
+
+    tool_records.each do |tool|
+      tool[:related_groups].each do |group_name|
+        actor = index[normalize_key(group_name)]
+        next unless actor
+
+        actor[:malware] ||= []
+        actor[:malware] << tool[:tool_name] unless actor[:malware].include?(tool[:tool_name])
+      end
+    end
+
+    records
+  end
+
+  def merge_record_data(base, extra)
+    merged = base.dup
+    %i[aliases sector_focus operations malware mitre_group_ids mitre_technique_ids].each do |field|
+      merged[field] = (Array(base[field]) + Array(extra[field])).map { |v| sanitize_text(v) }.reject(&:empty?).uniq.sort
+    end
+    merged[:description] = pick_better_description(base[:description], extra[:description], base[:display_name])
+    merged[:country] = base[:country].to_s.empty? ? extra[:country] : base[:country]
+    merged[:source_record_url] = base[:source_record_url].to_s.empty? ? extra[:source_record_url] : base[:source_record_url]
+    merged
+  end
+
+  def pick_better_description(left, right, display_name)
+    l = sanitize_text(left)
+    r = sanitize_text(right)
+    placeholder = "#{display_name} is tracked in ETDA/ThaiCERT threat group card data."
+    return r if l.empty? || l == placeholder
+    return l if r.empty? || r == placeholder
+    r.length > l.length ? r : l
+  end
+
+  def strip_html(value)
+    value.to_s.gsub(/<[^>]+>/, ' ')
+  end
+
+  def first_href(row_html)
+    href = row_html.to_s[/href=["']([^"']+)["']/i, 1].to_s
+    sanitize_url(href)
   end
 
   def normalize_record(record)

--- a/scripts/import-google-cloud-apt-groups.rb
+++ b/scripts/import-google-cloud-apt-groups.rb
@@ -1,0 +1,229 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'digest'
+require 'fileutils'
+require 'json'
+require 'net/http'
+require 'optparse'
+require 'time'
+require 'uri'
+require 'yaml'
+require 'cgi'
+require_relative 'actor_store'
+
+class GoogleCloudAptGroupsImporter
+  DEFAULT_SNAPSHOT_ROOT = 'data/imports/google-cloud-apt-groups'.freeze
+  SOURCE_NAME = 'Google Cloud APT Groups'.freeze
+  SOURCE_URL = 'https://cloud.google.com/security/resources/insights/apt-groups'.freeze
+  HTML_FILE = 'apt-groups.html'.freeze
+  JSON_FILE = 'apt-groups.json'.freeze
+
+  def initialize(argv)
+    @argv = argv.dup
+    @command = @argv.shift
+    @options = { output: nil, snapshot: nil, report_json: nil, write: false, actor_filters: [] }
+  end
+
+  def run
+    case @command
+    when 'fetch' then parse_fetch_options && fetch_snapshot
+    when 'plan' then parse_import_options && import_snapshot
+    when 'import' then parse_import_options && @options[:write] = true && import_snapshot
+    else
+      warn 'Usage: ruby scripts/import-google-cloud-apt-groups.rb fetch|plan|import [options]'
+      exit 1
+    end
+  end
+
+  private
+
+  def parse_fetch_options
+    OptionParser.new { |opts| opts.on('--output DIR') { |v| @options[:output] = v } }.parse!(@argv)
+    @options[:output] ||= File.join(DEFAULT_SNAPSHOT_ROOT, Time.now.utc.strftime('%Y-%m-%d'))
+  end
+
+  def parse_import_options
+    OptionParser.new do |opts|
+      opts.on('--snapshot PATH') { |v| @options[:snapshot] = v }
+      opts.on('--report-json PATH') { |v| @options[:report_json] = v }
+      opts.on('--actor NAME') { |v| @options[:actor_filters] << v }
+    end.parse!(@argv)
+    return if @options[:snapshot]
+
+    warn 'A snapshot path is required for plan/import.'
+    exit 1
+  end
+
+  def fetch_snapshot
+    FileUtils.mkdir_p(@options[:output])
+    html = http_get(URI.parse(SOURCE_URL))
+    html_path = File.join(@options[:output], HTML_FILE)
+    File.binwrite(html_path, html)
+    actors = extract_actors(html)
+    json_path = File.join(@options[:output], JSON_FILE)
+    File.write(json_path, JSON.pretty_generate({ 'actors' => actors }) + "\n")
+
+    manifest = {
+      'source_name' => SOURCE_NAME,
+      'source_url' => SOURCE_URL,
+      'retrieved_at' => Time.now.utc.iso8601,
+      'record_count' => actors.length,
+      'license_status' => 'Use as a secondary naming crosswalk with preserved source attribution.',
+      'checksums_sha256' => {
+        HTML_FILE => Digest::SHA256.file(html_path).hexdigest,
+        JSON_FILE => Digest::SHA256.file(json_path).hexdigest
+      }
+    }
+    File.write(File.join(@options[:output], 'manifest.yml'), YAML.dump(manifest))
+    puts "Fetched #{actors.length} Google Cloud APT group rows into #{@options[:output]}"
+  end
+
+  def import_snapshot
+    json_path = File.directory?(@options[:snapshot]) ? File.join(@options[:snapshot], JSON_FILE) : @options[:snapshot]
+    manifest_path = File.join(File.dirname(json_path), 'manifest.yml')
+    payload = JSON.parse(File.read(json_path))
+    manifest = File.exist?(manifest_path) ? YAML.safe_load(File.read(manifest_path), permitted_classes: [Time], aliases: true) : {}
+    actors = payload.fetch('actors', [])
+    existing = ActorStore.load_all
+    lookup = build_lookup(existing)
+
+    candidates = actors.filter_map do |row|
+      actor = lookup[norm(row['name'])]
+      next unless actor
+      next if @options[:actor_filters].any? { |f| norm(actor['name']) != norm(f) && norm(row['name']) != norm(f) }
+
+      build_candidate(actor, row, manifest)
+    end
+
+    report = {
+      'source' => SOURCE_NAME,
+      'snapshot' => @options[:snapshot],
+      'total_records' => actors.length,
+      'matched_existing_actors' => candidates.length,
+      'actors_with_description_updates' => candidates.count { |c| !c.dig('changes', 'description_update').to_s.empty? },
+      'updated_actor_names' => candidates.select { |c| c.dig('changes', 'new_aliases')&.any? }.map { |c| c['actor_name'] }.uniq.sort
+    }
+    File.write(@options[:report_json], JSON.pretty_generate(report) + "\n") if @options[:report_json]
+    puts JSON.pretty_generate(report)
+    return unless @options[:write]
+
+    apply_candidates(candidates, existing)
+    ActorStore.save_all(existing)
+  end
+
+  def build_lookup(existing)
+    existing.each_with_object({}) do |actor, memo|
+      ([actor['name']] + Array(actor['aliases'])).compact.each { |v| memo[norm(v)] = actor }
+    end
+  end
+
+  def build_candidate(actor, row, manifest)
+    existing_aliases = Array(actor['aliases']).map(&:to_s)
+    incoming_aliases = Array(row['aliases']).map(&:to_s)
+    new_aliases = incoming_aliases.reject { |value| existing_aliases.any? { |existing| norm(existing) == norm(value) } || norm(actor['name']) == norm(value) }
+
+    current_description = actor['description'].to_s.strip
+    incoming_description = row['description'].to_s.strip
+    description_update = merged_description(current_description, incoming_description, row['url'])
+
+    {
+      'actor_name' => actor['name'],
+      'changes' => { 'new_aliases' => new_aliases, 'description_update' => description_update },
+      'provenance' => {
+        'source_name' => SOURCE_NAME,
+        'source_url' => SOURCE_URL,
+        'retrieved_at' => manifest['retrieved_at'],
+        'source_dataset_url' => row['url'].to_s.empty? ? SOURCE_URL : row['url']
+      }
+    }
+  end
+
+  def apply_candidates(candidates, existing)
+    by_name = existing.each_with_object({}) { |actor, memo| memo[norm(actor['name'])] = actor }
+    candidates.each do |candidate|
+      actor = by_name[norm(candidate['actor_name'])]
+      next unless actor
+
+      actor['aliases'] ||= []
+      actor['aliases'] = (Array(actor['aliases']) + Array(candidate.dig('changes', 'new_aliases'))).uniq
+      description_update = candidate.dig('changes', 'description_update').to_s.strip
+      actor['description'] = description_update unless description_update.empty?
+      actor['provenance'] ||= {}
+      actor['provenance']['google_cloud_apt_groups'] = candidate['provenance']
+    end
+  end
+
+  def extract_actors(html)
+    actors = []
+    html.scan(%r{<a[^>]+href=["']([^"']+)["'][^>]*>(.*?)</a>}im) do |href, label|
+      next unless apt_group_href?(href)
+
+      name = strip_tags(label).strip
+      next if name.empty? || name.casecmp('APT groups and threat actors').zero?
+      description = extract_local_description(html, Regexp.last_match.end(0))
+
+      actors << {
+        'name' => name,
+        'aliases' => [],
+        'description' => description,
+        'url' => href.start_with?('http') ? href : "https://cloud.google.com#{href}"
+      }
+    end
+    actors.uniq { |row| norm(row['name']) }
+  end
+
+  def extract_local_description(html, start_index)
+    window = html[start_index, 600].to_s
+    text = strip_tags(window).strip
+    return '' if text.empty?
+
+    sentence = text.split(/(?<=[.!?])\s+/).first.to_s.strip
+    sentence.length > 30 ? sentence : ''
+  end
+
+  def strip_tags(value)
+    CGI.unescapeHTML(value.to_s.gsub(/<[^>]+>/, ' ')).gsub(/\s+/, ' ')
+  end
+
+  def merged_description(current_description, incoming_description, source_url)
+    return nil if incoming_description.empty?
+    return incoming_description if current_description.empty?
+    return nil if current_description.include?('### Source: Google Cloud APT Groups')
+
+    incoming_sentence = incoming_description.gsub(/\s+/, ' ').strip
+    section = [
+      '### Source: Google Cloud APT Groups',
+      incoming_sentence,
+      source_url.to_s.empty? ? SOURCE_URL : source_url.to_s
+    ].join("\n")
+
+    [current_description, section].join("\n\n")
+  end
+
+  def apt_group_href?(href)
+    normalized = CGI.unescapeHTML(href.to_s)
+    return true if normalized.start_with?('/security/resources/insights/apt-')
+
+    uri = URI.parse(normalized)
+    uri.host == 'cloud.google.com' && uri.path.start_with?('/security/resources/insights/apt-')
+  rescue URI::InvalidURIError
+    false
+  end
+
+  def http_get(uri, limit = 5)
+    raise "Too many redirects for #{uri}" if limit <= 0
+
+    response = Net::HTTP.get_response(uri)
+    return response.body if response.is_a?(Net::HTTPSuccess)
+    return http_get(URI.parse(response['location']), limit - 1) if response.is_a?(Net::HTTPRedirection) && !response['location'].to_s.empty?
+
+    raise "HTTP #{response.code} for #{uri}"
+  end
+
+  def norm(value)
+    value.to_s.downcase.gsub(/[^a-z0-9]+/, ' ').strip
+  end
+end
+
+GoogleCloudAptGroupsImporter.new(ARGV).run


### PR DESCRIPTION
### Motivation
- Add a lightweight crosswalk importer for Google Cloud APT Groups to enrich existing actors with aliases, descriptions, and provenance without creating new actors.
- Improve the ETDA/ThaiCERT importer to consume multiple ETDA feeds (cards, tools, groups, and mirror), merge overlapping records, and preserve curated descriptions by appending attributed source sections.
- Surface the new importer in the automated import runner and document the enrichment behavior so offline builds remain deterministic.

### Description
- Add a new importer script `scripts/import-google-cloud-apt-groups.rb` that implements `fetch`, `plan`, and `import` flows, extracts rows from the Google Cloud APT groups page, snapshots `apt-groups.html`/`apt-groups.json`, merges description text under an attributed `### Source: Google Cloud APT Groups` subsection, and records `provenance.google_cloud_apt_groups` on matched actors.
- Extend the ETDA/ThaiCERT importer (`scripts/import-etda-thaicert.rb`) to fetch multiple endpoints (`getcard.cgi?g=all&o=j`, `getcard.cgi?t=all&o=j`, `getmisp.cgi?o=g`, `aptgroups.cgi`, and a mirror), normalize and merge overlapping records, extract tool observations and attach tools as `malware` entries, add HTML-table parsing for group pages, merge descriptions via `merge_description_with_source`, and change manifest `source_url` to include all used URLs.
- Register the new Google Cloud source (and a couple of other sources shown) in the automated runner by updating `scripts/import-automated-sources.rb` with a `google-cloud-apt-groups` `Source` entry.
- Update documentation `docs/importers.md` to describe the Google Cloud importer and to note the enrichment behavior of appending attributed source subsections for description text.

### Testing
- No automated test suite was added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d7c3401483329fe3fff4eb719376)