### PR TITLE
Add Wiz Cloud Threat Landscape and Unit42 importers; register and document them

### DIFF
--- a/docs/importers.md
+++ b/docs/importers.md
@@ -101,6 +101,50 @@ Attribution pattern:
 
 `BreachHQ Threat Actors data (https://breach-hq.com/threat-actors) is used as a secondary index for reviewed matching and cross-source triage; linked reports and primary claims remain with the original publishers.`
 
+
+## Wiz Cloud Threat Landscape STIX importer
+
+`scripts/import-wiz-cloud-threat-landscape.rb` adds Wiz Cloud Threat Landscape as an enrichment source using the STIX feed as the canonical payload.
+
+- Canonical source feed: `https://www.wiz.io/api/feed/cloud-threat-landscape/stix.json`
+- Reference catalog pages covered by the same dataset:
+  - `https://threats.wiz.io/all-actors`
+  - `https://threats.wiz.io/all-techniques`
+  - `https://threats.wiz.io/all-tools`
+
+The importer follows `fetch -> plan -> import`:
+
+- `fetch` stores `stix.json` plus `manifest.yml` checksum metadata in `data/imports/wiz-cloud-threat-landscape/<YYYY-MM-DD>/`.
+- `plan` matches Wiz `intrusion-set` names/aliases to existing actors and reports candidate enrichments.
+- `import` enriches matched actors only by updating aliases and writing `provenance.wiz_cloud_threat_landscape` (record id, modified timestamp, related object refs, and retrieval metadata).
+
+Example commands:
+
+```bash
+ruby scripts/import-wiz-cloud-threat-landscape.rb fetch --output data/imports/wiz-cloud-threat-landscape/$(date -I)
+ruby scripts/import-wiz-cloud-threat-landscape.rb plan --snapshot data/imports/wiz-cloud-threat-landscape/2026-04-30 --report-json tmp/wiz-cloud-threat-landscape-report.json
+```
+
+
+## Unit 42 Threat Actor Groups importer
+
+`scripts/import-unit42-threat-actor-groups.rb` adds the Palo Alto Networks Unit 42 actor-group index as a secondary alias/provenance enrichment source.
+
+Source page (scraped snapshot):
+- https://unit42.paloaltonetworks.com/threat-actor-groups-tracked-by-palo-alto-networks-unit-42/
+
+Workflow:
+- `fetch` downloads the source page HTML and stores parsed actor rows under `data/imports/unit42-threat-actor-groups/<YYYY-MM-DD>/` (`page.html`, `actors.json`, `manifest.yml`).
+- `plan` matches parsed names/aliases to existing actors and reports candidate updates.
+- `import` enriches matched actors only by merging aliases and writing `provenance.unit42_threat_actor_groups` metadata.
+
+Example commands:
+
+```bash
+ruby scripts/import-unit42-threat-actor-groups.rb fetch --output data/imports/unit42-threat-actor-groups/$(date -I)
+ruby scripts/import-unit42-threat-actor-groups.rb plan --snapshot data/imports/unit42-threat-actor-groups/2026-04-30 --report-json tmp/unit42-threat-actor-groups-report.json
+```
+
 ## MITRE ATT&CK STIX Importer
 
 `scripts/import-mitre.rb` imports [MITRE ATT&CK](https://attack.mitre.org) STIX 2.1 bundles from [mitre-attack/attack-stix-data](https://github.com/mitre-attack/attack-stix-data).

--- a/scripts/import-automated-sources.rb
+++ b/scripts/import-automated-sources.rb
@@ -164,6 +164,14 @@ SOURCES = [
     fetch_limit: false
   ),
   Source.new(
+    key: 'wiz-cloud-threat-landscape',
+    label: 'Wiz Cloud Threat Landscape',
+    script: 'scripts/import-wiz-cloud-threat-landscape.rb',
+    snapshot_root: 'data/imports/wiz-cloud-threat-landscape',
+    report_name: 'wiz-cloud-threat-landscape-report.json',
+    fetch_limit: false
+  ),
+  Source.new(
     key: 'mitre-attack',
     label: 'MITRE ATT&CK',
     script: 'scripts/import-mitre.rb',
@@ -186,6 +194,14 @@ SOURCES = [
     script: 'scripts/import-sophos-threat-profiles.rb',
     snapshot_root: 'data/imports/sophos-threat-profiles',
     report_name: 'sophos-threat-profiles-report.json',
+    fetch_limit: false
+  ),
+  Source.new(
+    key: 'unit42-threat-actor-groups',
+    label: 'Unit 42 Threat Actor Groups',
+    script: 'scripts/import-unit42-threat-actor-groups.rb',
+    snapshot_root: 'data/imports/unit42-threat-actor-groups',
+    report_name: 'unit42-threat-actor-groups-report.json',
     fetch_limit: false
   )
 ].freeze

--- a/scripts/import-unit42-threat-actor-groups.rb
+++ b/scripts/import-unit42-threat-actor-groups.rb
@@ -1,0 +1,216 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'digest'
+require 'fileutils'
+require 'json'
+require 'net/http'
+require 'nokogiri'
+require 'optparse'
+require 'set'
+require 'time'
+require 'uri'
+require 'yaml'
+
+require_relative 'actor_store'
+require_relative 'import_utils'
+
+class Unit42ThreatActorGroupsImporter
+  DEFAULT_SNAPSHOT_ROOT = 'data/imports/unit42-threat-actor-groups'.freeze
+  SOURCE_NAME = 'Palo Alto Networks Unit 42 Threat Actor Groups'.freeze
+  SOURCE_URL = 'https://unit42.paloaltonetworks.com/threat-actor-groups-tracked-by-palo-alto-networks-unit-42/'.freeze
+  SOURCE_ATTRIBUTION = 'Aliases were reviewed from Palo Alto Networks Unit 42 threat actor group index and preserved with source provenance.'.freeze
+
+  def initialize(argv)
+    @argv = argv.dup
+    @command = @argv.shift
+    @options = { output: nil, snapshot: nil, report_json: nil, write: false }
+  end
+
+  def run
+    case @command
+    when 'fetch'
+      parse_fetch_options
+      fetch_snapshot
+    when 'plan'
+      parse_import_options
+      plan_or_import
+    when 'import'
+      parse_import_options
+      @options[:write] = true
+      plan_or_import
+    else
+      warn usage
+      exit 1
+    end
+  end
+
+  private
+
+  def usage
+    <<~TEXT
+      Usage: ruby scripts/import-unit42-threat-actor-groups.rb fetch|plan|import [options]
+    TEXT
+  end
+
+  def parse_fetch_options
+    OptionParser.new do |opts|
+      opts.banner = 'Usage: ruby scripts/import-unit42-threat-actor-groups.rb fetch [options]'
+      opts.on('--output DIR', 'Snapshot directory') { |value| @options[:output] = value }
+    end.parse!(@argv)
+    @options[:output] ||= File.join(DEFAULT_SNAPSHOT_ROOT, Time.now.utc.strftime('%Y-%m-%d'))
+  end
+
+  def parse_import_options
+    OptionParser.new do |opts|
+      opts.banner = 'Usage: ruby scripts/import-unit42-threat-actor-groups.rb plan|import --snapshot DIR [options]'
+      opts.on('--snapshot DIR', 'Snapshot directory') { |value| @options[:snapshot] = value }
+      opts.on('--report-json PATH', 'Write JSON report') { |value| @options[:report_json] = value }
+    end.parse!(@argv)
+    abort 'Missing --snapshot' if @options[:snapshot].to_s.empty?
+  end
+
+  def fetch_snapshot
+    FileUtils.mkdir_p(@options[:output])
+    html = http_get(SOURCE_URL)
+    actors = parse_actors_from_html(html)
+
+    File.write(File.join(@options[:output], 'page.html'), html)
+    File.write(File.join(@options[:output], 'actors.json'), JSON.pretty_generate(actors))
+    manifest = {
+      'source_name' => SOURCE_NAME,
+      'source_url' => SOURCE_URL,
+      'retrieved_at' => Time.now.utc.iso8601,
+      'source_checksum_sha256' => Digest::SHA256.hexdigest(html),
+      'record_count' => actors.length
+    }
+    File.write(File.join(@options[:output], 'manifest.yml'), YAML.dump(manifest))
+    puts "Wrote snapshot to #{@options[:output]} (#{actors.length} parsed records)"
+  end
+
+  def parse_actors_from_html(html)
+    doc = Nokogiri::HTML(html)
+    text_lines = doc.css('article p, article li, article td, article th, main p, main li, main td, main th').map { |n| n.text.strip }.reject(&:empty?)
+
+    records = text_lines.flat_map { |line| extract_names_from_line(line) }
+    normalize_records(records)
+  end
+
+  def extract_names_from_line(line)
+    cleaned = line.gsub(/[\u2013\u2014]/, '-').gsub(/\s+/, ' ').strip
+    return [] if cleaned.length < 4
+
+    matches = []
+    if cleaned =~ /\A([A-Za-z0-9 .\-]+?)\s*\((?:aka|AKA)\s+([^\)]+)\)/
+      primary = Regexp.last_match(1).strip
+      aliases = Regexp.last_match(2).split(/[\/,;]|\bor\b/i).map(&:strip).reject(&:empty?)
+      matches << { 'name' => primary, 'aliases' => aliases }
+    elsif cleaned =~ /\A([A-Za-z0-9 .\-]+?)\s*[:-]\s*([A-Za-z].+)/
+      name = Regexp.last_match(1).strip
+      tail = Regexp.last_match(2).strip
+      return [] if name.split.length > 6
+      matches << { 'name' => name, 'aliases' => tail.scan(/\b[A-Z][A-Za-z0-9\-]{2,}\b/).uniq.first(5) }
+    end
+    matches
+  end
+
+  def normalize_records(records)
+    grouped = {}
+    records.each do |record|
+      name = normalize_name(record['name'])
+      next if name.empty?
+
+      grouped[name] ||= Set.new
+      Array(record['aliases']).each do |alias_name|
+        normalized_alias = normalize_name(alias_name)
+        grouped[name] << normalized_alias unless normalized_alias.empty? || normalized_alias.casecmp?(name)
+      end
+    end
+
+    grouped.map do |name, aliases|
+      { 'name' => name, 'aliases' => aliases.to_a.sort }
+    end.sort_by { |entry| entry['name'].downcase }
+  end
+
+  def normalize_name(value)
+    value.to_s.gsub(/[\u2018\u2019]/, "'").gsub(/[\u201C\u201D]/, '"').gsub(/\s+/, ' ').strip
+  end
+
+  def plan_or_import
+    manifest = load_manifest
+    entries = load_entries
+    existing = ActorStore.load_all
+    alias_index = ImportUtils.build_alias_index(existing)
+
+    updates = entries.filter_map do |entry|
+      actor = ImportUtils.find_actor_by_names(alias_index, [entry['name'], *Array(entry['aliases'])])
+      next unless actor
+
+      {
+        actor_name: actor['name'],
+        data_path: actor['__data_path'],
+        source_name: entry['name'],
+        aliases: Array(entry['aliases'])
+      }
+    end
+
+    report = {
+      timestamp: Time.now.utc.iso8601,
+      source: SOURCE_NAME,
+      source_url: SOURCE_URL,
+      source_retrieved_at: manifest['retrieved_at'],
+      parsed_records: entries.length,
+      actors_with_updates: updates.length,
+      updates: updates.sort_by { |row| row[:actor_name] }
+    }
+
+    puts JSON.pretty_generate(report)
+    File.write(@options[:report_json], JSON.pretty_generate(report)) if @options[:report_json]
+    apply_updates(updates, manifest) if @options[:write]
+  end
+
+  def apply_updates(updates, manifest)
+    updates.each do |update|
+      actor = YAML.safe_load(File.read(update[:data_path]), permitted_classes: [], aliases: true) || {}
+      actor['aliases'] = (Array(actor['aliases']) + update[:aliases]).uniq.sort
+      actor['provenance'] ||= {}
+      actor['provenance']['unit42_threat_actor_groups'] = {
+        'source_name' => SOURCE_NAME,
+        'source_dataset_url' => SOURCE_URL,
+        'source_retrieved_at' => manifest['retrieved_at'] || Time.now.utc.iso8601,
+        'source_record_id' => update[:source_name]
+      }
+      actor['source_name'] ||= SOURCE_NAME
+      actor['source_attribution'] ||= SOURCE_ATTRIBUTION
+      File.write(update[:data_path], YAML.dump(actor))
+    end
+  end
+
+  def load_manifest
+    path = File.join(@options[:snapshot], 'manifest.yml')
+    abort "Missing #{path}" unless File.exist?(path)
+
+    YAML.safe_load(File.read(path), permitted_classes: [Time], aliases: true) || {}
+  end
+
+  def load_entries
+    path = File.join(@options[:snapshot], 'actors.json')
+    abort "Missing #{path}" unless File.exist?(path)
+
+    JSON.parse(File.read(path))
+  end
+
+  def http_get(url)
+    uri = URI.parse(url)
+    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+      req = Net::HTTP::Get.new(uri)
+      req['User-Agent'] = 'ThreatActor.info importer'
+      res = http.request(req)
+      raise "HTTP #{res.code} for #{url}" unless res.is_a?(Net::HTTPSuccess)
+
+      res.body
+    end
+  end
+end
+
+Unit42ThreatActorGroupsImporter.new(ARGV).run

--- a/scripts/import-wiz-cloud-threat-landscape.rb
+++ b/scripts/import-wiz-cloud-threat-landscape.rb
@@ -1,0 +1,204 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'digest'
+require 'fileutils'
+require 'json'
+require 'net/http'
+require 'optparse'
+require 'time'
+require 'uri'
+require 'yaml'
+
+require_relative 'actor_store'
+require_relative 'import_utils'
+
+class WizCloudThreatLandscapeImporter
+  DEFAULT_SNAPSHOT_ROOT = 'data/imports/wiz-cloud-threat-landscape'.freeze
+  SOURCE_NAME = 'Wiz Cloud Threat Landscape'.freeze
+  STIX_URL = 'https://www.wiz.io/api/feed/cloud-threat-landscape/stix.json'.freeze
+  SOURCE_ATTRIBUTION = 'Actor aliases and ATT&CK relationships imported from Wiz Cloud Threat Landscape STIX feed with provenance.'.freeze
+
+  def initialize(argv)
+    @argv = argv.dup
+    @command = @argv.shift
+    @options = { output: nil, snapshot: nil, write: false, report_json: nil }
+  end
+
+  def run
+    case @command
+    when 'fetch'
+      parse_fetch_options
+      fetch_snapshot
+    when 'plan'
+      parse_import_options
+      plan_or_import
+    when 'import'
+      parse_import_options
+      @options[:write] = true
+      plan_or_import
+    else
+      warn usage
+      exit 1
+    end
+  end
+
+  private
+
+  def usage
+    <<~TEXT
+      Usage: ruby scripts/import-wiz-cloud-threat-landscape.rb fetch|plan|import [options]
+
+      Examples:
+        ruby scripts/import-wiz-cloud-threat-landscape.rb fetch
+        ruby scripts/import-wiz-cloud-threat-landscape.rb plan --snapshot data/imports/wiz-cloud-threat-landscape/2026-04-30
+        ruby scripts/import-wiz-cloud-threat-landscape.rb import --snapshot data/imports/wiz-cloud-threat-landscape/2026-04-30
+    TEXT
+  end
+
+  def parse_fetch_options
+    OptionParser.new do |opts|
+      opts.banner = 'Usage: ruby scripts/import-wiz-cloud-threat-landscape.rb fetch [options]'
+      opts.on('--output DIR', 'Snapshot directory') { |value| @options[:output] = value }
+    end.parse!(@argv)
+    @options[:output] ||= File.join(DEFAULT_SNAPSHOT_ROOT, Time.now.utc.strftime('%Y-%m-%d'))
+  end
+
+  def parse_import_options
+    OptionParser.new do |opts|
+      opts.banner = 'Usage: ruby scripts/import-wiz-cloud-threat-landscape.rb plan|import --snapshot DIR [options]'
+      opts.on('--snapshot DIR', 'Snapshot directory containing manifest.yml and stix.json') { |value| @options[:snapshot] = value }
+      opts.on('--report-json PATH', 'Write plan report JSON') { |value| @options[:report_json] = value }
+    end.parse!(@argv)
+    abort 'Missing --snapshot' if @options[:snapshot].to_s.empty?
+  end
+
+  def fetch_snapshot
+    FileUtils.mkdir_p(@options[:output])
+    body = http_get(STIX_URL)
+    stix_path = File.join(@options[:output], 'stix.json')
+    File.binwrite(stix_path, body)
+
+    manifest = {
+      'source_name' => SOURCE_NAME,
+      'source_url' => STIX_URL,
+      'retrieved_at' => Time.now.utc.iso8601,
+      'source_checksum_sha256' => Digest::SHA256.hexdigest(body),
+      'includes' => {
+        'actors' => 'https://threats.wiz.io/all-actors',
+        'techniques' => 'https://threats.wiz.io/all-techniques',
+        'tools' => 'https://threats.wiz.io/all-tools'
+      }
+    }
+    File.write(File.join(@options[:output], 'manifest.yml'), YAML.dump(manifest))
+    puts "Wrote snapshot to #{@options[:output]}"
+  end
+
+  def plan_or_import
+    manifest = load_manifest
+    stix = load_stix
+    matched = match_updates(stix, manifest)
+    report = build_report(matched, manifest)
+
+    print_report(report)
+    File.write(@options[:report_json], JSON.pretty_generate(report)) if @options[:report_json]
+    apply_updates(matched, manifest) if @options[:write]
+  end
+
+  def load_manifest
+    manifest_file = File.join(@options[:snapshot], 'manifest.yml')
+    abort "Missing #{manifest_file}" unless File.exist?(manifest_file)
+
+    YAML.safe_load(File.read(manifest_file), permitted_classes: [Time], aliases: true) || {}
+  end
+
+  def load_stix
+    path = File.join(@options[:snapshot], 'stix.json')
+    abort "Missing #{path}" unless File.exist?(path)
+
+    JSON.parse(File.read(path))
+  end
+
+  def match_updates(stix, manifest)
+    objects = Array(stix['objects'])
+    intrusion_sets = objects.select { |obj| obj['type'] == 'intrusion-set' }
+    relationships = objects.select { |obj| obj['type'] == 'relationship' }
+
+    existing = ActorStore.load_all
+    alias_index = ImportUtils.build_alias_index(existing)
+
+    intrusion_sets.filter_map do |entry|
+      names = [entry['name'], *Array(entry['aliases'])].compact
+      actor = ImportUtils.find_actor_by_names(alias_index, names)
+      next unless actor
+
+      actor_relationships = relationships.select do |rel|
+        rel['source_ref'] == entry['id'] && %w[uses attributed-to].include?(rel['relationship_type'])
+      end
+
+      {
+        actor_name: actor['name'],
+        data_path: actor['__data_path'],
+        stix_id: entry['id'],
+        stix_modified: entry['modified'],
+        aliases: Array(entry['aliases']).compact.uniq,
+        related_object_refs: actor_relationships.map { |rel| rel['target_ref'] }.uniq.sort
+      }
+    end
+  end
+
+  def build_report(matched, manifest)
+    {
+      timestamp: Time.now.utc.iso8601,
+      source: SOURCE_NAME,
+      source_url: manifest['source_url'] || STIX_URL,
+      retrieved_at: manifest['retrieved_at'],
+      actors_with_updates: matched.length,
+      updates: matched.sort_by { |record| record[:actor_name] }
+    }
+  end
+
+  def print_report(report)
+    puts "\n=== #{SOURCE_NAME} Import Plan ==="
+    puts "Source URL: #{report[:source_url]}"
+    puts "Retrieved at: #{report[:retrieved_at]}"
+    puts "Actors with updates: #{report[:actors_with_updates]}"
+    report[:updates].each do |entry|
+      puts "  - #{entry[:actor_name]} | aliases +#{entry[:aliases].length} | related refs #{entry[:related_object_refs].length}"
+    end
+    puts "\n=== Run with import to apply ===" unless @options[:write]
+  end
+
+  def apply_updates(matched, manifest)
+    matched.each do |entry|
+      actor = YAML.safe_load(File.read(entry[:data_path]), permitted_classes: [], aliases: true) || {}
+      actor['provenance'] ||= {}
+      actor['provenance']['wiz_cloud_threat_landscape'] = {
+        'source_name' => SOURCE_NAME,
+        'source_dataset_url' => manifest['source_url'] || STIX_URL,
+        'source_retrieved_at' => manifest['retrieved_at'] || Time.now.utc.iso8601,
+        'source_record_id' => entry[:stix_id],
+        'source_record_modified' => entry[:stix_modified],
+        'related_object_refs' => entry[:related_object_refs]
+      }
+      actor['aliases'] = (Array(actor['aliases']) + entry[:aliases]).uniq.sort
+      actor['source_name'] ||= SOURCE_NAME
+      actor['source_attribution'] ||= SOURCE_ATTRIBUTION
+      File.write(entry[:data_path], YAML.dump(actor))
+    end
+  end
+
+  def http_get(url)
+    uri = URI.parse(url)
+    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+      req = Net::HTTP::Get.new(uri)
+      req['User-Agent'] = 'ThreatActor.info importer'
+      res = http.request(req)
+      raise "HTTP #{res.code} for #{url}" unless res.is_a?(Net::HTTPSuccess)
+
+      res.body
+    end
+  end
+end
+
+WizCloudThreatLandscapeImporter.new(ARGV).run


### PR DESCRIPTION
### Motivation

- Add two new secondary enrichment sources (Wiz STIX feed and Unit 42 actor-group index) to expand alias/provenance coverage for existing actors.
- Expose both sources to the automated importer orchestration so they can be fetched, planned, and optionally applied with the same snapshot workflow.

### Description

- Added `scripts/import-wiz-cloud-threat-landscape.rb` which fetches the Wiz STIX feed, generates snapshots (`stix.json` + `manifest.yml`), matches `intrusion-set` entries to existing actors, and optionally writes provenance under `provenance.wiz_cloud_threat_landscape` while merging aliases and related object refs.
- Added `scripts/import-unit42-threat-actor-groups.rb` which scrapes the Unit 42 actor-group page, stores `page.html`, `actors.json`, and `manifest.yml`, matches parsed names/aliases to existing actors, and optionally merges aliases with provenance under `provenance.unit42_threat_actor_groups`.
- Registered both new sources in `scripts/import-automated-sources.rb` so they appear in the `SOURCES` list and can be run via the automated runner.
- Updated `docs/importers.md` to document both importers, their snapshot formats, example commands, canonical source URLs, and the fields recorded in provenance.

### Testing

- Performed syntax checks on the new scripts using `ruby -c` and confirmed no syntax errors.
- Ran the repository's automated test suite (`rake test`) and the linter (`rubocop`) and observed no failures related to the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3e639a4488332ae17e0a7dde15925)