### PR TITLE
Add fallback canonical source links and importer attribution docs

### DIFF
--- a/_layouts/threat_actor.html
+++ b/_layouts/threat_actor.html
@@ -399,6 +399,57 @@ layout: default
           {% if source_data.source_dataset_url %}
           <a href="{{ source_data.source_dataset_url }}">Dataset</a>
           {% endif %}
+          {% assign fallback_source_url = nil %}
+          {% if source[0] == 'misp_galaxy' %}
+            {% assign fallback_source_url = 'https://github.com/MISP/misp-galaxy' %}
+          {% elsif source[0] == 'ransomlook' %}
+            {% assign fallback_source_url = 'https://www.ransomlook.io/' %}
+          {% elsif source[0] == 'etda_thaicert' %}
+            {% assign fallback_source_url = 'https://apt.etda.or.th/' %}
+          {% elsif source[0] == 'malpedia' %}
+            {% assign fallback_source_url = 'https://malpedia.caad.fkie.fraunhofer.de/' %}
+          {% elsif source[0] == 'microsoft_threat_actor_list' %}
+            {% assign fallback_source_url = 'https://learn.microsoft.com/en-us/defender-xdr/microsoft-threat-actor-naming' %}
+          {% elsif source[0] == 'apt_groups_operations' %}
+            {% assign fallback_source_url = 'https://apt.threattracking.com/' %}
+          {% elsif source[0] == 'aptnotes' %}
+            {% assign fallback_source_url = 'https://github.com/aptnotes/data' %}
+          {% elsif source[0] == 'ransomware_tool_matrix' %}
+            {% assign fallback_source_url = 'https://github.com/BushidoUK/Ransomware-Tool-Matrix' %}
+          {% elsif source[0] == 'curated_intel_moveit_transfer' %}
+            {% assign fallback_source_url = 'https://github.com/curated-intel/MOVEit-Transfer' %}
+          {% elsif source[0] == 'ransomware_vulnerability_matrix' %}
+            {% assign fallback_source_url = 'https://github.com/BushidoUK/Ransomware-Vulnerability-Matrix' %}
+          {% elsif source[0] == 'russian_apt_tool_matrix' %}
+            {% assign fallback_source_url = 'https://github.com/BushidoUK/Russian-APT-Tool-Matrix' %}
+          {% elsif source[0] == 'breach_hq' %}
+            {% assign fallback_source_url = 'https://breach-hq.com/threat-actors' %}
+          {% elsif source[0] == 'bushido_breach_reports' %}
+            {% assign fallback_source_url = 'https://github.com/BushidoUK/Breach-Report-Collection' %}
+          {% elsif source[0] == 'reddrip7_apt_digital_weapon' %}
+            {% assign fallback_source_url = 'https://github.com/RedDrip7/APT_Digital_Weapon' %}
+          {% elsif source[0] == 'eternal_liberty' %}
+            {% assign fallback_source_url = 'https://github.com/StrangerealIntel/EternalLiberty' %}
+          {% elsif source[0] == 'aptmap' %}
+            {% assign fallback_source_url = 'https://github.com/dkbuster/aptmap' %}
+          {% elsif source[0] == 'google_cloud_apt_groups' %}
+            {% assign fallback_source_url = 'https://cloud.google.com/blog/topics/threat-intelligence/apt-groups' %}
+          {% elsif source[0] == 'wiz_cloud_threat_landscape' %}
+            {% assign fallback_source_url = 'https://threats.wiz.io/all-actors' %}
+          {% elsif source[0] == 'rapid7_aba_detections' %}
+            {% assign fallback_source_url = 'https://github.com/rapid7/aba-detections' %}
+          {% elsif source[0] == 'sophos_threat_profiles' %}
+            {% assign fallback_source_url = 'https://github.com/sophos/traffic-decoder-data/tree/main/threat-profiles' %}
+          {% elsif source[0] == 'dragos_threat_groups' %}
+            {% assign fallback_source_url = 'https://www.dragos.com/threat-groups' %}
+          {% elsif source[0] == 'unit42_threat_actor_groups' %}
+            {% assign fallback_source_url = 'https://unit42.paloaltonetworks.com/threat-actor-groups-tracked-by-palo-alto-networks-unit-42/' %}
+          {% elsif source[0] == 'mitre' %}
+            {% assign fallback_source_url = 'https://attack.mitre.org/' %}
+          {% endif %}
+          {% if fallback_source_url and source_data.source_record_url == nil and source_data.source_repository == nil and source_data.source_dataset_url == nil %}
+          <a href="{{ fallback_source_url }}">Source homepage</a>
+          {% endif %}
         </li>
           {% endif %}
         {% endfor %}

--- a/docs/importers.md
+++ b/docs/importers.md
@@ -2,6 +2,42 @@
 
 This repository supports source importers that update `_data/actors/*.yml` and regenerate `_threat_actors/*.md` without introducing build-time network dependencies.
 
+## Source attribution and outbound links
+
+Use these canonical upstream links when documenting imports, provenance blocks, or Source Attribution notes so each dataset receives explicit credit.
+
+| Source key | Source name | Canonical link(s) |
+|---|---|---|
+| `misp-galaxy` | MISP Galaxy | https://github.com/MISP/misp-galaxy |
+| `ransomlook` | RansomLook | https://www.ransomlook.io/ ; https://github.com/RansomLook/RansomLook |
+| `etda-thaicert` | ETDA / ThaiCERT Threat Group Cards | https://apt.etda.or.th/ |
+| `malpedia` | Malpedia (Fraunhofer FKIE) | https://malpedia.caad.fkie.fraunhofer.de/ |
+| `microsoft-threat-actor-list` | Microsoft Threat Actor List | https://learn.microsoft.com/en-us/defender-xdr/microsoft-threat-actor-naming |
+| `apt-groups-operations` | APT Groups & Operations | https://apt.threattracking.com/ |
+| `aptnotes` | APTnotes | https://github.com/aptnotes/data |
+| `ransomware-tool-matrix` | BushidoUK Ransomware Tool Matrix | https://github.com/BushidoUK/Ransomware-Tool-Matrix |
+| `curated-intel-moveit-transfer` | Curated Intelligence MOVEit Transfer Tracking | https://github.com/curated-intel/MOVEit-Transfer |
+| `ransomware-vulnerability-matrix` | BushidoUK Ransomware Vulnerability Matrix | https://github.com/BushidoUK/Ransomware-Vulnerability-Matrix |
+| `russian-apt-tool-matrix` | BushidoUK Russian APT Tool Matrix | https://github.com/BushidoUK/Russian-APT-Tool-Matrix |
+| `breach-hq-threat-actors` | BreachHQ Threat Actors | https://breach-hq.com/threat-actors |
+| `bushido-breach-reports` | BushidoToken Breach Report Collection | https://github.com/BushidoUK/Breach-Report-Collection |
+| `reddrip7-apt-digital-weapon` | RedDrip7 APT_Digital_Weapon | https://github.com/RedDrip7/APT_Digital_Weapon |
+| `eternal-liberty` | EternalLiberty | https://github.com/StrangerealIntel/EternalLiberty |
+| `aptmap` | APTmap | https://github.com/dkbuster/aptmap |
+| `google-cloud-apt-groups` | Google Cloud APT Groups | https://cloud.google.com/blog/topics/threat-intelligence/apt-groups |
+| `wiz-cloud-threat-landscape` | Wiz Cloud Threat Landscape | https://www.wiz.io/api/feed/cloud-threat-landscape/stix.json ; https://threats.wiz.io/all-actors |
+| `rapid7-aba-detections` | Rapid7 ABA Detections | https://github.com/rapid7/aba-detections |
+| `sophos-threat-profiles` | Sophos Threat Profiles | https://github.com/sophos/traffic-decoder-data/tree/main/threat-profiles |
+| `dragos-threat-groups` | Dragos Threat Groups | https://www.dragos.com/threat-groups |
+| `unit42-threat-actor-groups` | Unit 42 Threat Actor Groups | https://unit42.paloaltonetworks.com/threat-actor-groups-tracked-by-palo-alto-networks-unit-42/ |
+| `mitre-attack` | MITRE ATT&CK | https://attack.mitre.org/ ; https://github.com/mitre-attack/attack-stix-data |
+
+When adding or updating importers:
+
+- Add the source to this table and to `/attribution/` in `attribution.md` in the same PR.
+- Ensure provenance metadata stores a stable `source_dataset_url` (or equivalent source URL field).
+- Keep attribution text clear that this project is a secondary index and that linked reports remain owned by original publishers.
+
 ## RansomLook Importer
 
 `scripts/import-ransomlook.rb` is the first importer.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -92,6 +92,14 @@ ruby scripts/validate-content.rb
 
 ## Import Scripts
 
+## Attribution requirement for import sources
+
+Every importer change must preserve source credit and outbound links:
+
+- Update `attribution.md` (`/attribution/` page) with source name, usage, and canonical URL(s).
+- Update `docs/importers.md` source attribution table when a source is added/renamed.
+- Preserve provenance URL fields in `_data/actors/*.yml` (for example `source_dataset_url`) so actor pages can link back to upstream sources.
+
 ### import-automated-sources.rb
 
 Run the standard automated import set. Analyst notes are intentionally excluded from this runner and stay a separate manual enrichment path.


### PR DESCRIPTION
### Motivation

- Provide stable outbound links on actor pages when a specific `source_record_url`, `source_repository`, or `source_dataset_url` is missing by falling back to canonical upstream homepages.
- Make importer responsibilities explicit so new or renamed sources are credited with canonical URLs and provenance metadata.

### Description

- Add `fallback_source_url` logic to `_layouts/threat_actor.html` that maps known source keys to canonical upstream URLs and renders a "Source homepage" link when no record/repo/dataset URL is present.
- Populate mappings for many sources (for example `misp_galaxy`, `malpedia`, `microsoft_threat_actor_list`, `aptnotes`, `mitre`, and others) in the layout conditionals.
- Update `docs/importers.md` with a source attribution table listing source keys, display names, and canonical link(s), and add guidance for adding/updating importers and provenance fields.
- Add an "Attribution requirement for import sources" section to `scripts/README.md` documenting process requirements to update `attribution.md` and `docs/importers.md` and to preserve provenance URL fields in `_data/actors/*.yml`.

### Testing

- Ran content validation with `ruby scripts/validate-content.rb` and it completed successfully.
- Regenerated pages and indexes with `ruby scripts/generate-pages.rb --force` and `ruby scripts/generate-indexes.rb` and re-ran `ruby scripts/validate-content.rb` with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3ec1fa0b8833294020fc570b82506)