### PR TITLE
Handle unsupported ETDA response formats gracefully

### DIFF
--- a/scripts/import-etda-thaicert.rb
+++ b/scripts/import-etda-thaicert.rb
@@ -15,6 +15,9 @@ require 'yaml'
 require_relative 'actor_store'
 
 class EtdaThaicertImporter
+  class UnsupportedResponseFormatError < StandardError; end
+  class SourceAuthenticationError < StandardError; end
+
   PAGE_DIR = '_threat_actors'.freeze
   DEFAULT_SNAPSHOT_ROOT = 'data/imports/etda-thaicert'.freeze
   DEFAULT_OVERRIDES_FILE = 'data/imports/etda-thaicert/mapping_overrides.yml'.freeze
@@ -171,6 +174,11 @@ class EtdaThaicertImporter
 
       payload = http_get(url)
       payloads << { payload: payload, source_url: url }
+    rescue UnsupportedResponseFormatError => e
+      warn "Fetch warning for #{url}: #{e.message}"
+      warn "Response snippet: #{response_snippet(e.respond_to?(:body) ? e.body : nil)}"
+    rescue SourceAuthenticationError => e
+      warn "Fetch warning for #{url}: #{e.message}"
     rescue StandardError => e
       warn "Fetch failed for #{url}: #{e.message}"
     end
@@ -927,16 +935,49 @@ class EtdaThaicertImporter
       raise "Redirect without location for #{url}" if location.to_s.empty?
 
       http_get(location, limit - 1)
+    when Net::HTTPUnauthorized
+      if url == @options[:mirror_url]
+        raise SourceAuthenticationError, "HTTP 401 from mirror; continuing with primary ETDA sources"
+      end
+
+      raise "HTTP #{response.code} for #{url}"
     else
       raise "HTTP #{response.code} for #{url}"
     end
   end
 
   def parse_response_body(body)
-    JSON.parse(body)
+    text = body.to_s
+    JSON.parse(text)
   rescue JSON::ParserError
-    rows = CSV.parse(body, headers: true)
+    unless csv_like_payload?(text)
+      error = UnsupportedResponseFormatError.new('Unsupported response format')
+      error.define_singleton_method(:body) { text }
+      raise error
+    end
+
+    rows = CSV.parse(text, headers: true)
     rows.map(&:to_h)
+  rescue CSV::MalformedCSVError
+    error = UnsupportedResponseFormatError.new('Unsupported response format')
+    error.define_singleton_method(:body) { text }
+    raise error
+  end
+
+  def csv_like_payload?(body)
+    lines = body.to_s.lines.map(&:strip).reject(&:empty?)
+    return false if lines.empty?
+
+    first_line = lines.first
+    return true if first_line.include?(',') || first_line.include?(';') || first_line.include?("\t")
+
+    false
+  end
+
+  def response_snippet(body)
+    return '(empty response)' if body.to_s.strip.empty?
+
+    body.to_s.lines.first.to_s.strip[0, 200]
   end
 
   def safe_load_yaml_file(path)


### PR DESCRIPTION
### Motivation
- Avoid noisy `CSV::MalformedCSVError` / "Illegal quoting" logs when ETDA endpoints return HTML or error pages instead of JSON/CSV.
- Continue the import when one source fails and ensure the mirror's `HTTP 401` doesn't block falling back to primary ETDA sources.
- Provide concise, actionable warnings showing the source URL and a short response snippet to aid troubleshooting.

### Description
- Added two custom error classes: `UnsupportedResponseFormatError` and `SourceAuthenticationError` to differentiate parse failures from mirror auth issues.
- Reworked `parse_response_body` to keep JSON parsing first, perform a quick CSV-sanity check via `csv_like_payload?` before attempting CSV parsing, and convert `CSV::MalformedCSVError` into `UnsupportedResponseFormatError` while attaching the raw body for diagnostics.
- Updated `http_get` to treat `Net::HTTPUnauthorized` (`HTTP 401`) from the configured mirror URL as a non-fatal `SourceAuthenticationError` so primary sources can still be used.
- Updated `fetch_source_payloads` to catch `UnsupportedResponseFormatError` and `SourceAuthenticationError`, print concise warnings including a snippet via `response_snippet`, and continue to the next source.

### Testing
- Ran a syntax check with `ruby -c scripts/import-etda-thaicert.rb`, which returned `Syntax OK`.
- No full import was executed as part of this change; runtime behavior should be verified by running `ruby scripts/import-etda-thaicert.rb fetch` against the real endpoints or snapshots in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa128901d483329b8d2b51d0d7e552)