### PR TITLE
Improve ETDA importer diagnostics for invalid JSON-like responses

### DIFF
--- a/scripts/import-etda-thaicert.rb
+++ b/scripts/import-etda-thaicert.rb
@@ -175,8 +175,9 @@ class EtdaThaicertImporter
       payload = http_get(url)
       payloads << { payload: payload, source_url: url }
     rescue UnsupportedResponseFormatError => e
-      warn "Fetch warning for #{url}: #{e.message}"
-      warn "Response snippet: #{response_snippet(e.respond_to?(:body) ? e.body : nil)}"
+      reason = e.respond_to?(:reason) ? e.reason : e.message
+      warn "Fetch warning for #{url}: #{reason}"
+      warn "Response snippet: #{response_snippet(e.respond_to?(:body) ? e.body : nil, include_non_empty_lines: true)}"
     rescue SourceAuthenticationError => e
       warn "Fetch warning for #{url}: #{e.message}"
     rescue StandardError => e
@@ -949,10 +950,21 @@ class EtdaThaicertImporter
   def parse_response_body(body)
     text = body.to_s
     JSON.parse(text)
-  rescue JSON::ParserError
+  rescue JSON::ParserError => e
+    parse_error = e.message
+    if text.lstrip.start_with?('{', '[')
+      error = UnsupportedResponseFormatError.new('Invalid JSON payload')
+      error.define_singleton_method(:body) { text }
+      error.define_singleton_method(:reason) { 'Invalid JSON payload' }
+      error.define_singleton_method(:parse_error) { parse_error }
+      raise error
+    end
+
     unless csv_like_payload?(text)
       error = UnsupportedResponseFormatError.new('Unsupported response format')
       error.define_singleton_method(:body) { text }
+      error.define_singleton_method(:reason) { 'Unsupported response format' }
+      error.define_singleton_method(:parse_error) { parse_error }
       raise error
     end
 
@@ -961,6 +973,7 @@ class EtdaThaicertImporter
   rescue CSV::MalformedCSVError
     error = UnsupportedResponseFormatError.new('Unsupported response format')
     error.define_singleton_method(:body) { text }
+    error.define_singleton_method(:reason) { 'Unsupported response format' }
     raise error
   end
 
@@ -974,10 +987,16 @@ class EtdaThaicertImporter
     false
   end
 
-  def response_snippet(body)
+  def response_snippet(body, include_non_empty_lines: false)
     return '(empty response)' if body.to_s.strip.empty?
 
-    body.to_s.lines.first.to_s.strip[0, 200]
+    snippet = body.to_s.lines.first.to_s.strip[0, 200]
+    return snippet unless include_non_empty_lines
+
+    lines = body.to_s.lines.map(&:strip).reject(&:empty?).first(2).map { |line| line[0, 200] }
+    return snippet if lines.empty?
+
+    "#{snippet} | #{lines.join(' | ')}"
   end
 
   def safe_load_yaml_file(path)


### PR DESCRIPTION
### Motivation
- Improve debugability when `JSON.parse` fails on payloads that look like JSON so operators can see the parser error and a more informative snippet.
- Avoid noisy CSV parse errors for non-CSV JSON-like responses while preserving the CSV fallback for genuinely CSV payloads.

### Description
- Capture the JSON parser error (`JSON::ParserError#message`) inside `parse_response_body` before attempting CSV fallback.  
- When the payload starts with `{` or `[` and JSON parsing fails, raise `UnsupportedResponseFormatError` with reason `Invalid JSON payload` and attach the response `body` plus `parse_error` metadata.  
- Surface the structured `reason` in `fetch_source_payloads` warning output so the URL warning line includes the short failure reason.  
- Expand `response_snippet` with an optional `include_non_empty_lines:` mode that appends the first 1–2 non-empty trimmed lines (making single-character snippets like `{` actionable) while keeping the original single-line default.

### Testing
- Ran a Ruby syntax check with `ruby -c scripts/import-etda-thaicert.rb`, which reported `Syntax OK`.
- No full site validation or builds were run as part of this change; behavior preserves existing control flow to continue processing remaining sources on warnings.}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa151b2918833292667c16267fc38d)