### PR TITLE
Report and skip malformed existing pages during ETDA planning (add `--strict-pages`)

### DIFF
--- a/scripts/import-etda-thaicert.rb
+++ b/scripts/import-etda-thaicert.rb
@@ -59,7 +59,8 @@ class EtdaThaicertImporter
       report_json: nil,
       write: false,
       force: false,
-      new_only: false
+      new_only: false,
+      strict_pages: false
     }
     @overrides = {
       excluded_group_keys: [],
@@ -133,6 +134,7 @@ class EtdaThaicertImporter
       opts.on('--overrides PATH', 'Override mapping file') { |value| @options[:overrides_file] = value }
       opts.on('--force', 'Allow protected field updates') { @options[:force] = true }
       opts.on('--new-only', 'Only create new actors; no updates to existing') { @options[:new_only] = true }
+      opts.on('--strict-pages', 'Fail when an existing page has malformed front matter') { @options[:strict_pages] = true }
     end
     parser.parse!(@argv)
     return if @options[:snapshot]
@@ -193,12 +195,14 @@ class EtdaThaicertImporter
     records = records.first(@options[:limit]) if @options[:limit]
 
     existing_actors = ActorStore.load_all
+    @page_parse_warnings = []
     existing_pages = load_pages
     evaluation = evaluate_records(records, existing_actors)
 
     report = build_report(evaluation)
     File.write(@options[:report_json], JSON.pretty_generate(report) + "\n") if @options[:report_json]
     print_report(evaluation)
+    print_page_warning_summary if @command == 'plan'
 
     return unless @options[:write]
 
@@ -1011,6 +1015,25 @@ class EtdaThaicertImporter
   def load_pages
     Dir.glob(File.join(PAGE_DIR, '*.md')).each_with_object({}) do |path, pages|
       pages[path] = parse_page(path)
+    rescue RuntimeError => e
+      raise if @options[:strict_pages]
+
+      @page_parse_warnings ||= []
+      @page_parse_warnings << { path: path, error: concise_page_parse_error(e.message) }
+    end
+  end
+
+  def concise_page_parse_error(message)
+    message.to_s.split("\n").first.to_s.strip
+  end
+
+  def print_page_warning_summary
+    warnings = Array(@page_parse_warnings)
+    return if warnings.empty?
+
+    warn "Page parse warnings: #{warnings.length} malformed existing page(s) skipped"
+    warnings.each do |entry|
+      warn "  - #{entry[:path]}: #{entry[:error]}"
     end
   end
 


### PR DESCRIPTION
### Motivation
- Avoid aborting a `plan` run when a single existing actor page has malformed front matter so the importer can continue evaluating valid records and surface actionable warnings.
- Preserve an option for strict failure behavior to match CI requirements when desired.

### Description
- Added a new importer option `--strict-pages` with default `strict_pages: false` to keep strict behavior opt-in for `plan|import` runs.
- Initialize `@page_parse_warnings` and updated `load_pages` to rescue per-file `RuntimeError` from `parse_page`, record concise warnings (`path` + short error) and skip only the offending file while continuing to build `existing_pages` from valid files.
- Added `concise_page_parse_error` to extract a short, one-line parse message and `print_page_warning_summary` to emit a summary (count + file list) after the normal `plan` report.
- `synchronize_existing_page` and other importer flows remain unchanged except they use the pruned `existing_pages` map when pages were skipped.

### Testing
- Ran `ruby -c scripts/import-etda-thaicert.rb` and it returned `Syntax OK`.
- No repository-wide test suite exists; change is limited to parsing flow and relies on existing importer runtime behavior and CI when `--strict-pages` is used.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa1523da188332bef3d0819a945b89)