### PR TITLE
Fix validation: ensure aliases: [] is always serialized for new actor…

### DIFF
--- a/.github/workflows/import-sources.yml
+++ b/.github/workflows/import-sources.yml
@@ -37,6 +37,11 @@ jobs:
     - name: Install dependencies
       run: bundle install
 
+    - name: Clean stale threat-actor markdown files
+      run: |
+        git clean -fd _threat_actors/ 2>/dev/null || true
+        rm -f _threat_actors/{nagini-ransomware,sigrun-ransomware,trumplocker-ransomware,yashma}.md
+
     - name: Run automated source imports
       env:
         SOURCE: ${{ github.event.inputs.source || '' }}

--- a/scripts/actor_store.rb
+++ b/scripts/actor_store.rb
@@ -96,7 +96,7 @@ module ActorStore
       next unless normalized.key?(key)
 
       value = normalized[key]
-      next if value.nil? || value == '' || value == []
+      next if value.nil? || value == '' || (value == [] && key != 'aliases')
 
       lines.concat(serialize_field(key, value, 0))
     end
@@ -104,7 +104,7 @@ module ActorStore
     remaining_keys = normalized.keys - FIELD_ORDER
     remaining_keys.sort.each do |key|
       value = normalized[key]
-      next if value.nil? || value == '' || value == []
+      next if value.nil? || value == '' || (value == [] && key != 'aliases')
 
       lines.concat(serialize_field(key, value, 0))
     end

--- a/scripts/import-ransomlook.rb
+++ b/scripts/import-ransomlook.rb
@@ -345,7 +345,7 @@ class RansomLookImporter
   def build_new_actor(record)
     {
       'name' => record[:display_name],
-      'aliases' => record[:aliases],
+      'aliases' => Array(record[:aliases]),
       'description' => build_description(record),
       'url' => record[:url],
       'last_activity' => record[:last_activity],
@@ -355,7 +355,7 @@ class RansomLookImporter
       'source_license' => LICENSE_NAME,
       'source_license_url' => LICENSE_URL,
       'provenance' => build_provenance(record)
-    }.reject { |_key, value| value.nil? || value == [] }
+    }.reject { |key, value| value.nil? || (value == [] && key != 'aliases') }
   end
 
   def build_actor_updates(existing_actor, record)


### PR DESCRIPTION
… records

- ActorStore.serialize_actor now preserves empty aliases arrays
- build_new_actor uses Array() to guarantee aliases is always an array
- Clean stale threat-actor markdown files before import in workflow

## Description

## Related Issue

## Type of Change

- [ ] Bug fix (non-breaking change)
- [ ] New threat actor (non-breaking change)
- [ ] Documentation update
- [ ] Code quality improvement

## Testing

## Checklists

- [ ] My code follows the style guidelines
- [ ] I have performed a self-review
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix works
- [ ] New and existing tests pass

## Source Attribution

For threat actor data changes, confirm source licensing:
- [ ] Data is CC0 licensed
- [ ] Data is CC BY 4.0 licensed
- [ ] I have permission to use this data
- [ ] Data is from a public source with attribution