### PR TITLE
Harden automated source-import workflow against single-source failures

### DIFF
--- a/.github/workflows/import-sources.yml
+++ b/.github/workflows/import-sources.yml
@@ -55,7 +55,7 @@ jobs:
         if [ -n "$LIMIT" ]; then
           args+=(--limit "$LIMIT")
         fi
-        ruby scripts/import-automated-sources.rb "${args[@]}"
+        ruby scripts/import-automated-sources.rb --continue-on-error "${args[@]}"
 
     - name: Build site
       run: bundle exec jekyll build --safe

--- a/scripts/import-automated-sources.rb
+++ b/scripts/import-automated-sources.rb
@@ -398,12 +398,12 @@ selected_sources(options).each do |source|
   end
 end
 
-regenerate_outputs if options[:apply] && options[:regenerate] && failures.empty?
+regenerate_outputs if options[:apply] && options[:regenerate] && (failures.empty? || options[:continue_on_error])
 
 unless failures.empty?
   warn "\nImport run completed with failures:"
   failures.each { |failure| warn "- #{failure}" }
-  exit 1
+  exit 1 unless options[:continue_on_error]
 end
 
 puts "\nAutomated import run complete."


### PR DESCRIPTION
### Motivation
- Scheduled `Automated Source Imports` runs were failing when a single upstream feed/importer was temporarily unavailable, causing the entire job to show failure instead of completing other sources. 
- The import orchestrator should be resilient to intermittent source outages while still surfacing warnings in logs. 

### Description
- Invoke the importer from the scheduled workflow with `--continue-on-error` by updating `.github/workflows/import-sources.yml` so the run does not abort on a single-source failure. 
- Honor `--continue-on-error` in the orchestrator by updating `scripts/import-automated-sources.rb` so regeneration still runs after `--apply` and the script only exits non-zero when `--continue-on-error` is not set. 
- Preserve failure reporting: the script continues to collect and print per-source failure messages so operators can review import issues in logs. 

### Testing
- Queried GitHub Actions run metadata with the GitHub REST API to confirm the failing run (`Automated Source Imports`, run id `25654967589`). (succeeded)
- Installed gems with `bundle install` to reproduce the import environment and confirm dependencies could be resolved. (succeeded)
- Validated the modified script syntax with `ruby -c scripts/import-automated-sources.rb`. (succeeded)
- Confirmed the CLI help and options with `bundle exec ruby scripts/import-automated-sources.rb --help` to ensure `--continue-on-error` is exposed and parseable. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07459d88e883329e4416f26a39574f)