### PR TITLE
Integrate Beazley Security Labs Atom feeds for articles and advisories

### DIFF
--- a/_data/news_feed.yml
+++ b/_data/news_feed.yml
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-05-15T05:52:57Z",
+  "updated": "2026-05-15T16:23:46Z",
   "sources": [
     "BleepingComputer",
     "The Hacker News",
@@ -19,6 +19,14 @@
     "Rapid7"
   ],
   "actor_news": {
+    "REvil": [
+      {
+        "title": "Best Early Memorial Day Deals: Garmin, Birdfy, Breville (2026)",
+        "link": "https://www.wired.com/story/best-memorial-day-deals-2026/",
+        "date": "2026-05-15T14:26:31+00:00",
+        "source": "Wired"
+      }
+    ],
     "Cobalt": [
       {
         "title": "Ghostwriter Targets Ukrainian Government With Geofenced PDF Phishing, Cobalt Strike",

--- a/scripts/fetch-news.rb
+++ b/scripts/fetch-news.rb
@@ -10,6 +10,7 @@ require 'rss'
 require 'open-uri'
 require 'yaml'
 require 'json'
+require 'rexml/document'
 
 OUTPUT_FILE = '_data/news_feed.yml'
 
@@ -166,29 +167,45 @@ def fetch_beazley_articles
   articles = []
   
   begin
-    url = "https://labs.beazley.security/articles"
-    html = URI.parse(url).open(read_timeout: 10).read
-    
-    # Find article links using regex
-    html.scan(/<a href="(\/articles\/[^"]+)"[^>]*>([^<]+)<\/a>/).first(15).each do |match|
-      href, title = match
-      next if title.strip.empty?
-      
-      full_url = "https://labs.beazley.security#{href}"
-      articles << {
-        title: title.strip[0..200],
-        link: full_url,
-        source: 'Beazley Security Labs',
-        date: nil,
-        weight: 2
-      }
+    feeds = [
+      { url: 'https://labs.beazley.security/articles/atom.xml', source: 'Beazley Security Labs Articles' },
+      { url: 'https://labs.beazley.security/advisories/atom.xml', source: 'Beazley Security Labs Advisories' }
+    ]
+
+    feeds.each do |feed|
+      raw = URI.parse(feed[:url]).open(read_timeout: 10).read
+      articles.concat(parse_beazley_atom_entries(raw, feed[:source]))
     end
+
+    articles.uniq! { |item| item[:link] }
     @beazley_count = articles.size
   rescue => e
     puts "  Beazley: #{e.message[0..30]}"
   end
   
   articles
+end
+
+def parse_beazley_atom_entries(xml, source)
+  doc = REXML::Document.new(xml)
+  entries = []
+
+  REXML::XPath.each(doc, '//entry') do |entry|
+    title = entry.elements['title']&.text&.strip
+    link = entry.elements['link']&.attributes&.[]('href')&.strip
+    published = entry.elements['published']&.text&.strip || entry.elements['updated']&.text&.strip
+    next if title.to_s.empty? || link.to_s.empty?
+
+    entries << {
+      title: title[0..200],
+      link: link,
+      source: source,
+      date: published,
+      weight: 2
+    }
+  end
+
+  entries.first(15)
 end
 
 def map_actors_to_news(news_items)

--- a/scripts/scrape-beazley.rb
+++ b/scripts/scrape-beazley.rb
@@ -1,35 +1,48 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Beazley Security Labs scraper (no nokogiri)
+# Beazley Security Labs feed fetcher
 require 'open-uri'
+require 'rexml/document'
 
 def fetch_beazley_articles
+  feeds = [
+    { url: 'https://labs.beazley.security/articles/atom.xml', source: 'Beazley Security Labs Articles' },
+    { url: 'https://labs.beazley.security/advisories/atom.xml', source: 'Beazley Security Labs Advisories' }
+  ]
   articles = []
-  
-  begin
-    url = "https://labs.beazley.security/articles"
-    html = URI.parse(url).open(read_timeout: 10).read
-    
-    # Find article links using regex
-    # Pattern: <a href="/articles/slug">Title</a>
-    html.scan(/<a href="(\/articles\/[^"]+)"[^>]*>([^<]+)<\/a>/).first(15).each do |match|
-      href, title = match
-      next if title.strip.empty?
-      
-      full_url = "https://labs.beazley.security#{href}"
-      articles << {
-        title: title.strip[0..200],
-        link: full_url,
-        source: 'Beazley Security Labs',
-        date: nil
-      }
+
+  feeds.each do |feed|
+    begin
+      raw = URI.parse(feed[:url]).open(read_timeout: 10).read
+      articles.concat(parse_beazley_atom_entries(raw, feed[:source]))
+    rescue => e
+      puts "Beazley #{feed[:source]}: #{e.message[0..40]}"
     end
-  rescue => e
-    puts "Beazley: #{e.message[0..40]}"
   end
-  
-  articles
+
+  articles.uniq { |item| item[:link] }
+end
+
+def parse_beazley_atom_entries(xml, source)
+  doc = REXML::Document.new(xml)
+  entries = []
+
+  REXML::XPath.each(doc, '//entry') do |entry|
+    title = entry.elements['title']&.text&.strip
+    link = entry.elements['link']&.attributes&.[]('href')&.strip
+    published = entry.elements['published']&.text&.strip || entry.elements['updated']&.text&.strip
+    next if title.to_s.empty? || link.to_s.empty?
+
+    entries << {
+      title: title[0..200],
+      link: link,
+      source: source,
+      date: published
+    }
+  end
+
+  entries.first(15)
 end
 
 # Test


### PR DESCRIPTION
### Motivation
- Replace brittle HTML regex scraping of Beazley pages with reliable Atom feed ingestion to improve coverage and robustness.
- Ingest both Beazley feeds so advisories and articles are included (`/articles/atom.xml` and `/advisories/atom.xml`).

### Description
- Updated `scripts/fetch-news.rb` to fetch both Beazley Atom feeds and added `parse_beazley_atom_entries` using `REXML` to extract `title`, `link`, and `published/updated` values and set `weight: 2` for these entries.
- Added deduplication by `link` and preserved the existing per-feed cap by returning the first 15 entries per feed in the parser.
- Updated `scripts/scrape-beazley.rb` to use the same feed-based parsing and `REXML`-backed `parse_beazley_atom_entries` helper instead of HTML regex scraping.
- Adjusted `require` lines to include `rexml/document` and regenerated the news output file at `_data/news_feed.yml` with the updated fetcher behavior.

### Testing
- Ran `ruby scripts/scrape-beazley.rb` to verify the standalone fetcher and it completed successfully and returned feed entries.
- Ran `ruby scripts/fetch-news.rb` to verify end-to-end aggregation and it completed successfully and wrote `_data/news_feed.yml`.
- No automated test failures were observed during these runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a074832430c8332ab7435655391f8c7)