### PR TITLE
Guard advanced CodeQL workflow when default setup is enabled

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,9 @@ permissions:
 
 jobs:
   analyze:
+    # This workflow uses advanced CodeQL configuration. It must not run while
+    # GitHub's Code Scanning "default setup" is enabled for this repository.
+    if: ${{ vars.CODEQL_ADVANCED_SETUP_ENABLED == 'true' }}
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     strategy:
@@ -33,3 +36,13 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
+
+  explain-skip:
+    if: ${{ vars.CODEQL_ADVANCED_SETUP_ENABLED != 'true' }}
+    name: Advanced CodeQL disabled
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain why this workflow is skipped
+        run: |
+          echo "Skipping advanced CodeQL workflow because CODEQL_ADVANCED_SETUP_ENABLED is not 'true'."
+          echo "If you want to run this workflow, disable Code Scanning default setup in repository settings and set repository variable CODEQL_ADVANCED_SETUP_ENABLED=true."


### PR DESCRIPTION
### Motivation
- GitHub rejects SARIF uploads from advanced CodeQL configurations while the Code Scanning "default setup" is enabled, which produced noisy failures and blocked processing. 
- The workflow should be disabled by default and clearly explain how to enable the advanced path to avoid accidental failures.

### Description
- Added a guard to the `analyze` job in `.github/workflows/codeql.yml` with `if: ${{ vars.CODEQL_ADVANCED_SETUP_ENABLED == 'true' }}` so the advanced workflow only runs when the repository variable is set. 
- Added an `explain-skip` job with `if: ${{ vars.CODEQL_ADVANCED_SETUP_ENABLED != 'true' }}` that prints guidance on disabling the default setup and setting `CODEQL_ADVANCED_SETUP_ENABLED=true`. 
- Included an inline comment describing why the advanced workflow must not run while the default setup is enabled.

### Testing
- A prior CodeQL run produced a SARIF processing error: `Code Scanning could not process the submitted SARIF file`, demonstrating the failure mode this change addresses. 
- Verified the workflow modification with `git diff -- .github/workflows/codeql.yml` and `nl -ba .github/workflows/codeql.yml`, and committed the change with `git commit`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07517bfa408332bb5c89aaf7a84c9c)