### PR TITLE
Support actor YAML files and normalize/dedupe keywords in fetch-news.rb

### DIFF
--- a/scripts/fetch-news.rb
+++ b/scripts/fetch-news.rb
@@ -11,6 +11,7 @@ require 'open-uri'
 require 'yaml'
 require 'json'
 require 'rexml/document'
+require 'set'
 
 OUTPUT_FILE = '_data/news_feed.yml'
 
@@ -97,6 +98,48 @@ ACTOR_KEYWORDS = {
   'Sidewinder' => ['sidewinder', 'groundbait'],
 }.freeze
 
+def normalize_keyword(keyword)
+  keyword.to_s.strip.downcase
+end
+
+def load_actor_keywords
+  actor_files = Dir.glob('_data/actors/*.yml').sort
+  keywords = Hash.new { |h, k| h[k] = Set.new }
+
+  actor_files.each do |path|
+    actor = YAML.safe_load(File.read(path), permitted_classes: [Date, Time], aliases: false)
+    next unless actor.is_a?(Hash)
+
+    actor_name = actor['name'].to_s.strip
+    next if actor_name.empty?
+
+    keywords[actor_name] << normalize_keyword(actor_name)
+
+    Array(actor['aliases']).each do |ali|
+      normalized = normalize_keyword(ali)
+      keywords[actor_name] << normalized unless normalized.empty?
+    end
+  rescue Psych::SyntaxError => e
+    puts "  Warning: #{path} - #{e.message.lines.first.to_s.strip}"
+  end
+
+  keywords
+end
+
+def combined_actor_keywords
+  combined = Hash.new { |h, k| h[k] = Set.new }
+
+  ACTOR_KEYWORDS.each do |actor, words|
+    words.each { |word| combined[actor] << normalize_keyword(word) }
+  end
+
+  load_actor_keywords.each do |actor, words|
+    words.each { |word| combined[actor] << word }
+  end
+
+  combined
+end
+
 def parse_feed(feed)
   items = []
   
@@ -128,8 +171,10 @@ def match_actors(title, text)
   
   matched = []
   
-  ACTOR_KEYWORDS.each do |actor, keywords|
+  combined_actor_keywords.each do |actor, keywords|
     keywords.each do |kw|
+      next if kw.empty?
+
       if title_lower.include?(kw) || text_lower.include?(kw)
         matched << actor
         break


### PR DESCRIPTION
### Motivation

- Extend the news fetcher to incorporate actor names and aliases defined in `_data/actors/*.yml` so that feed matching is driven by both the hardcoded `ACTOR_KEYWORDS` and authoritatively maintained actor files.
- Normalize and deduplicate keywords to reduce false negatives and redundant matches during actor name detection.

### Description

- Added a `require 'set'` and implemented `normalize_keyword`, `load_actor_keywords`, and `combined_actor_keywords` helper functions to read and normalize actor names and aliases from `_data/actors/*.yml` and merge them with the existing `ACTOR_KEYWORDS` into `Set`s.
- Switched `match_actors` to iterate `combined_actor_keywords` instead of the hardcoded `ACTOR_KEYWORDS` and skip empty keywords to avoid spurious matches.
- Use `YAML.safe_load` when reading actor files and rescue `Psych::SyntaxError` to emit a warning for malformed YAML files.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a3c095e808332bff4e64f316b5d73)