### PR TITLE
Replace Kernel.open with File.open in vendored ffi generator

### DIFF
--- a/vendor/bundle/ruby/3.0.0/gems/ffi-1.16.3/lib/ffi/tools/generator.rb
+++ b/vendor/bundle/ruby/3.0.0/gems/ffi-1.16.3/lib/ffi/tools/generator.rb
@@ -78,7 +78,7 @@ module FFI
         new_lines.join "\n"
       end
 
-      open @rb_name, 'w' do |f|
+      File.open(@rb_name, 'w') do |f|
         f.puts "# This file is generated from `#{@ffi_name}'. Do not edit."
         f.puts
         f.puts new_file
@@ -102,4 +102,3 @@ module FFI
 
   end
 end
-


### PR DESCRIPTION
### Motivation
- Remediate a CodeQL `rb/non-constant-kernel-open` finding by eliminating use of `Kernel.open` in the vendored `ffi` generator to avoid potential command injection when non-constant paths are used.

### Description
- Replace `open @rb_name, 'w' do |f|` with `File.open(@rb_name, 'w') do |f|` in `vendor/bundle/ruby/3.0.0/gems/ffi-1.16.3/lib/ffi/tools/generator.rb` so the File API is used instead of the vulnerable Kernel sink.

### Testing
- Ran `ruby -c vendor/bundle/ruby/3.0.0/gems/ffi-1.16.3/lib/ffi/tools/generator.rb` and the syntax check returned `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a3d5c5fd08332b2a93e5266b2ce59)