### PR TITLE
Fix unsafe `open` usage in FFI generator and tighten attribute parsing in REXML

### DIFF
--- a/vendor/bundle/ruby/3.0.0/gems/ffi-1.16.3/lib/ffi/tools/generator.rb
+++ b/vendor/bundle/ruby/3.0.0/gems/ffi-1.16.3/lib/ffi/tools/generator.rb
@@ -78,7 +78,7 @@ module FFI
         new_lines.join "\n"
       end
 
-      open @rb_name, 'w' do |f|
+      File.open(@rb_name, 'w') do |f|
         f.puts "# This file is generated from `#{@ffi_name}'. Do not edit."
         f.puts
         f.puts new_file
@@ -102,4 +102,3 @@ module FFI
 
   end
 end
-

--- a/vendor/bundle/ruby/3.0.0/gems/rexml-3.2.8/lib/rexml/parsers/baseparser.rb
+++ b/vendor/bundle/ruby/3.0.0/gems/rexml-3.2.8/lib/rexml/parsers/baseparser.rb
@@ -624,10 +624,12 @@ module REXML
             prefix = match[2]
             local_part = match[3]
 
-            unless @source.match(/\s*=\s*/um, true)
+            @source.match(/\s*/um, true)
+            unless @source.match("=", true)
               message = "Missing attribute equal: <#{name}>"
               raise REXML::ParseException.new(message, @source)
             end
+            @source.match(/\s*/um, true)
             unless match = @source.match(/(['"])/, true)
               message = "Missing attribute value start quote: <#{name}>"
               raise REXML::ParseException.new(message, @source)


### PR DESCRIPTION
### Motivation

- Prevent ambiguous or potentially unsafe use of the kernel `open` by using `File.open` when writing generated files.  
- Fix brittle attribute parsing in `REXML::Parsers::BaseParser#parse_attributes` so whitespace around `=` is handled deterministically and missing tokens are detected reliably.

### Description

- Replaced `open @rb_name, 'w' do |f|` with `File.open(@rb_name, 'w') do |f|` in the FFI generator to explicitly open a file for writing.  
- In `rexml/parsers/baseparser.rb` added explicit consumption of optional whitespace before and after the attribute `=` and changed the `=` check to a direct match so attribute assignment parsing is stable.  
- Left existing error messages and quote handling intact while moving whitespace consumption to explicit `@source.match(/
*/um, true)` calls for clarity and correctness.

### Testing

- Ran the project's Ruby test suite (including `bundle exec rake test` and `bundle exec rspec`), and all tests related to parsing and generator output passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a3d5c5fd08332b2a93e5266b2ce59)