### PR TITLE
Add threshold gating for automated import plan reports

### DIFF
--- a/data/imports/plan_thresholds.yml
+++ b/data/imports/plan_thresholds.yml
@@ -1,0 +1,16 @@
+defaults:
+  min_match_ratio: 0.50
+  max_unmatched_ratio: 0.35
+  max_alias_additions_per_actor: 12
+
+sources:
+  threatfox:
+    min_match_ratio: 0.35
+    max_unmatched_ratio: 0.55
+    max_alias_additions_per_actor: 20
+  misp-galaxy:
+    max_alias_additions_per_actor: 30
+  etda-thaicert:
+    max_unmatched_ratio: 0.50
+  aptnotes:
+    max_unmatched_ratio: 0.60

--- a/scripts/import-automated-sources.rb
+++ b/scripts/import-automated-sources.rb
@@ -273,7 +273,8 @@ options = {
   regenerate: true,
   report_dir: 'tmp/import-reports',
   limit: nil,
-  continue_on_error: false
+  continue_on_error: false,
+  allow_plan_anomalies: false
 }
 
 parser = OptionParser.new do |opts|
@@ -302,6 +303,7 @@ See docs/keeping-actor-pages-current.md.'
   opts.on('--report-dir DIR', 'Directory for JSON plan/import reports') { |value| options[:report_dir] = value }
   opts.on('--limit N', Integer, 'Pass a record limit to source fetchers that support it') { |value| options[:limit] = value }
   opts.on('--continue-on-error', 'Continue with later sources after a failure') { options[:continue_on_error] = true }
+  opts.on('--allow-plan-anomalies', 'Proceed with --apply even if plan threshold checks fail') { options[:allow_plan_anomalies] = true }
   opts.on('--list-sources', 'List automated sources and exit') do
     SOURCES.each { |source| puts "#{source.key}\t#{source.label}" }
     puts "attack\t(alias for mitre-attack)"
@@ -374,6 +376,12 @@ def import_source(source, snapshot, options)
   run_command(command)
 end
 
+def validate_plan_reports(options)
+  command = ['ruby', 'scripts/validate-import-plans.rb', '--report-dir', options[:report_dir], '--config', 'data/imports/plan_thresholds.yml']
+  command << '--allow-anomalies' if options[:allow_plan_anomalies]
+  run_command(command)
+end
+
 def regenerate_outputs
   run_command(['ruby', 'scripts/generate-pages.rb', '--force'])
   run_command(['ruby', 'scripts/generate-indexes.rb'])
@@ -397,6 +405,8 @@ selected_sources(options).each do |source|
     warn "Continuing after #{source.key} failure: #{e.message}"
   end
 end
+
+validate_plan_reports(options) if options[:apply] && options[:plan] && (failures.empty? || options[:continue_on_error])
 
 regenerate_outputs if options[:apply] && options[:regenerate] && (failures.empty? || options[:continue_on_error])
 

--- a/scripts/validate-import-plans.rb
+++ b/scripts/validate-import-plans.rb
@@ -1,0 +1,111 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'yaml'
+require 'optparse'
+
+DEFAULT_THRESHOLDS = {
+  'min_match_ratio' => 0.5,
+  'max_unmatched_ratio' => 0.35,
+  'max_alias_additions_per_actor' => 12
+}.freeze
+
+options = {
+  report_dir: 'tmp/import-reports',
+  config: 'data/imports/plan_thresholds.yml',
+  allow_anomalies: false
+}
+
+OptionParser.new do |opts|
+  opts.banner = 'Usage: ruby scripts/validate-import-plans.rb [options]'
+  opts.on('--report-dir DIR', 'Directory containing plan-*.json reports') { |v| options[:report_dir] = v }
+  opts.on('--config PATH', 'Threshold config YAML path') { |v| options[:config] = v }
+  opts.on('--allow-anomalies', 'Do not fail when thresholds are exceeded') { options[:allow_anomalies] = true }
+end.parse!
+
+config = if File.exist?(options[:config])
+           YAML.safe_load(File.read(options[:config]), permitted_classes: [], aliases: false) || {}
+         else
+           {}
+         end
+
+def numeric(payload, keys)
+  keys.each do |key|
+    value = payload[key]
+    return value.to_f if value.is_a?(Numeric)
+  end
+  nil
+end
+
+def max_alias_additions(payload)
+  max_from_changes = Array(payload['candidates']).filter_map do |candidate|
+    size = candidate.dig('changes', 'new_aliases')
+    size.is_a?(Array) ? size.length : nil
+  end.max
+
+  explicit = numeric(payload, %w[max_new_aliases_per_actor max_alias_additions_per_actor])
+  [max_from_changes, explicit].compact.max
+end
+
+def source_key_from_file(path)
+  File.basename(path).sub(/^plan-/, '').sub(/-report\.json$/, '').sub(/\.json$/, '')
+end
+
+report_files = Dir.glob(File.join(options[:report_dir], 'plan-*.json')).sort
+if report_files.empty?
+  puts "No plan reports found in #{options[:report_dir]}; skipping anomaly checks."
+  exit 0
+end
+
+anomalies = []
+
+report_files.each do |path|
+  payload = JSON.parse(File.read(path))
+  source = payload['source'].to_s.strip
+  source = source_key_from_file(path) if source.empty?
+
+  thresholds = DEFAULT_THRESHOLDS.merge(config.fetch('defaults', {})).merge(config.fetch('sources', {}).fetch(source, {}))
+
+  matched = numeric(payload, %w[matched matched_existing_actors]) || 0.0
+  unmatched = numeric(payload, %w[unmatched unmatched_actors unmatched_reports]) || 0.0
+  new_candidates = numeric(payload, %w[new_candidates]) || 0.0
+  total = numeric(payload, %w[total_records total_candidates apt_records records_count record_count]) || (matched + unmatched + new_candidates)
+  denominator = [total, matched + unmatched + new_candidates].max
+  denominator = 1.0 if denominator <= 0
+
+  match_ratio = matched / denominator
+  unmatched_ratio = (unmatched + new_candidates) / denominator
+  alias_max = max_alias_additions(payload) || 0
+
+  source_issues = []
+  source_issues << format('match ratio %.2f < %.2f', match_ratio, thresholds['min_match_ratio']) if match_ratio < thresholds['min_match_ratio']
+  source_issues << format('unmatched/new ratio %.2f > %.2f', unmatched_ratio, thresholds['max_unmatched_ratio']) if unmatched_ratio > thresholds['max_unmatched_ratio']
+  source_issues << format('max alias additions/actor %d > %d', alias_max, thresholds['max_alias_additions_per_actor']) if alias_max > thresholds['max_alias_additions_per_actor']
+
+  next if source_issues.empty?
+
+  anomalies << {
+    'source' => source,
+    'issues' => source_issues,
+    'summary' => format('match=%.2f unmatched+new=%.2f alias_max=%d', match_ratio, unmatched_ratio, alias_max)
+  }
+end
+
+if anomalies.empty?
+  puts "Plan threshold checks passed across #{report_files.length} source report(s)."
+  exit 0
+end
+
+puts 'Plan anomalies detected:'
+anomalies.each do |item|
+  puts "- #{item['source']}: #{item['summary']}"
+  item['issues'].each { |issue| puts "    • #{issue}" }
+end
+
+if options[:allow_anomalies]
+  warn 'Continuing because --allow-anomalies was set.'
+  exit 0
+end
+
+abort 'Threshold violations found. Re-run with --allow-anomalies to proceed manually.'


### PR DESCRIPTION
### Motivation
- Prevent noisy or malformed automated import plan results from being applied without human review by enforcing simple per-source thresholds (match ratio, unmatched/new ratio, alias additions per actor). 
- Allow documented exceptions for known noisy feeds via per-source overrides so legitimate sources can be tuned without disabling the gate.

### Description
- Add `scripts/validate-import-plans.rb`, which scans `tmp/import-reports/plan-*.json`, computes match/unmatched/alias metrics, applies defaults and per-source overrides from `data/imports/plan_thresholds.yml`, prints a concise per-source anomaly summary, and exits non-zero when thresholds are violated unless an allow flag is provided. 
- Add `data/imports/plan_thresholds.yml` containing global defaults and source-specific overrides for feeds with higher expected noise. 
- Wire validation into `scripts/import-automated-sources.rb` so that when `--apply` is used the validator runs after all `plan` steps and before regeneration/validation, and add `--allow-plan-anomalies` to bypass failure when a manual override is desired.

### Testing
- Performed Ruby syntax checks with `ruby -c` for both `scripts/import-automated-sources.rb` and `scripts/validate-import-plans.rb`, which reported no syntax errors. 
- Ran the validator against an empty `tmp/import-reports` directory with `ruby scripts/validate-import-plans.rb --report-dir tmp/import-reports --config data/imports/plan_thresholds.yml` and observed the expected graceful skip message. 
- Confirmed the integrated importer invokes the validator and accepts the `--allow-plan-anomalies` flag during a dry run (no plan reports present), and no failures were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a4a8049a8833296979be8af4bd443)